### PR TITLE
remove maxchars for copy+paste support

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -340,7 +340,6 @@
             'defaultText': 'Add More',
             'removeWithBackspace': true,
             'minChars': 0,
-            'maxChars': 18,
             'placeholderColor': '#666666'
         });
 
@@ -352,7 +351,6 @@
             'defaultText': 'Add More',
             'removeWithBackspace': true,
             'minChars': 0,
-            'maxChars': 18,
             'placeholderColor': '#666666'
         });
 

--- a/templates/clients.html
+++ b/templates/clients.html
@@ -250,7 +250,6 @@ Wireguard Clients
                     'defaultText': 'Add More',
                     'removeWithBackspace': true,
                     'minChars': 0,
-                    'maxChars': 18,
                     'placeholderColor': '#666666'
                 });
 
@@ -262,7 +261,6 @@ Wireguard Clients
                     'defaultText': 'Add More',
                     'removeWithBackspace': true,
                     'minChars': 0,
-                    'maxChars': 18,
                     'placeholderColor': '#666666'
                 });
 

--- a/templates/global_settings.html
+++ b/templates/global_settings.html
@@ -154,7 +154,6 @@ Global Settings
             'defaultText': 'Add More',
             'removeWithBackspace': true,
             'minChars': 0,
-            'maxChars': 18,
             'placeholderColor': '#666666'
         });
 

--- a/templates/server.html
+++ b/templates/server.html
@@ -160,7 +160,6 @@ Wireguard Server Settings
             'defaultText': 'Add More',
             'removeWithBackspace': true,
             'minChars': 0,
-            'maxChars': 18,
             'placeholderColor': '#666666'
         });
 


### PR DESCRIPTION
```
'maxChars': 18,
```
seems reasonable, unless you want to copy+paste a list of cidrs. then it sorta prevents that from working.
Even in the most optimal way, the tags input library works like this:

![Peek 2021-04-23 13-34](https://user-images.githubusercontent.com/1844847/115915767-659fe180-a439-11eb-8904-aacb603be934.gif)

Which is also how it works on their example site: http://xoxco.com/projects/code/tagsinput/example.html

Some thoughts on this topic of pasting are documented here: https://github.com/xoxco/jQuery-Tags-Input/issues/22

I would offer a better PR but this unblocked me, and I'm currently suffering from an unrelated :joy: splitting headache.

---

If that rambling wasn't clear, this allows you to paste something like this:

```
192.168.1.0/24,192.168.2.0/24,192.168.3.0/24,192.168.4.0/24,192.168.5.0/24
```

Into the tags input fields, and have them persist correctly.