### PR TITLE
Allow user defined user/password combo for local authentication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG BUILD_DEPENDENCIES="npm \
 
 # Get dependencies
 RUN apk add --update --no-cache ${BUILD_DEPENDENCIES}
-
+ENV USER=admin PASS=admin
 WORKDIR /build
 
 # Add sources

--- a/util/db.go
+++ b/util/db.go
@@ -15,8 +15,8 @@ import (
 )
 
 const dbPath = "./db"
-const defaultUsername = "admin"
-const defaultPassword = "admin"
+const defaultUsername = os.Getenv("USER")
+const defaultPassword = os.Getenv("PASSS")
 const defaultServerAddress = "10.252.1.0/24"
 const defaultServerPort = 51820
 const defaultDNS = "1.1.1.1"


### PR DESCRIPTION
Adds default environment variables USER and PASS to the Dockerfile and reads those environment variables when creating the user database. Can be utilized as follows:

```yaml
version: "2.1"
services:
  wireguard:
    image: ngoduykhanh/wireguard-ui:latest
    container_name: wireguard-ui
    ports:
      - 5000:5000
    environment:
      - USER=some_username
      - PASS=some_password

```