### PR TITLE
Port forwarding for server

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -13,6 +13,7 @@ import (
 
 	rice "github.com/GeertJohan/go.rice"
 	externalip "github.com/glendc/go-external-ip"
+	"github.com/labstack/gommon/log"
 	"github.com/ngoduykhanh/wireguard-ui/model"
 	"github.com/sdomino/scribble"
 )
@@ -36,6 +37,8 @@ func BuildClientConfig(client model.Client, server model.Server, setting model.G
 		desiredHost = split[0]
 		if n, err := strconv.Atoi(split[1]); err == nil {
 			desiredPort = n
+		} else {
+			log.Error("Endpoint appears to be incorrectly formated: ", err)
 		}
 	}
 	peerEndpoint := fmt.Sprintf("Endpoint = %s:%d", desiredHost, desiredPort)

--- a/util/util.go
+++ b/util/util.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -27,7 +28,18 @@ func BuildClientConfig(client model.Client, server model.Server, setting model.G
 	peerPublicKey := fmt.Sprintf("PublicKey = %s", server.KeyPair.PublicKey)
 	peerPresharedKey := fmt.Sprintf("PresharedKey = %s", client.PresharedKey)
 	peerAllowedIPs := fmt.Sprintf("AllowedIPs = %s", strings.Join(client.AllowedIPs, ","))
-	peerEndpoint := fmt.Sprintf("Endpoint = %s:%d", setting.EndpointAddress, server.Interface.ListenPort)
+
+	desiredHost := setting.EndpointAddress
+	desiredPort := server.Interface.ListenPort
+	if strings.Contains(desiredHost, ":") {
+		split := strings.Split(desiredHost, ":")
+		desiredHost = split[0]
+		if n, err := strconv.Atoi(split[1]); err == nil {
+			desiredPort = n
+		}
+	}
+	peerEndpoint := fmt.Sprintf("Endpoint = %s:%d", desiredHost, desiredPort)
+
 	peerPersistentKeepalive := fmt.Sprintf("PersistentKeepalive = %d", setting.PersistentKeepalive)
 
 	// build the config as string


### PR DESCRIPTION
In my case I am using wireguard behind reverse proxy. This PR contains implementation of _setting.EndpointAddress_ parsing, so that client config contains desired hostname and port, if _EndpointAddress_ string contains ":int" suffix. Default behavior maintained otherwise.

Usage:
Fill **Endpoint Address** field in **Global Settings** with hostname:port format e.g. example.com:443
_ListenPort_ setting in server configuration will remain as set in **Wireguard Server** page, but example.com:443 will be used as _Endpoint_ of server's peer in every client config.