### PR TITLE
Service from README does not work on EL 8.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ After=network.target
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/systemctl restart wg-quick@wg0.service
+
+[Install]
+RequiredBy=wgui.path
 ```
 
 Create /etc/systemd/system/wgui.path


### PR DESCRIPTION
The `wgui.service` is missing a required property:

```
[root@wireguard wireguard-ui]# systemctl enable wgui.service
The unit files have no installation config (WantedBy, RequiredBy, Also, Alias
settings in the [Install] section, and DefaultInstance for template units).
This means they are not meant to be enabled using systemctl.
Possible reasons for having this kind of units are:
1) A unit may be statically enabled by being symlinked from another unit's
   .wants/ or .requires/ directory.
2) A unit's purpose may be to act as a helper for some other unit which has
   a requirement dependency on it.
3) A unit may be started when needed via activation (socket, path, timer,
   D-Bus, udev, scripted systemctl call, ...).
4) In case of template units, the unit is meant to be enabled with some
   instance name specified.
```

This PR adds the `RequiredBy` property to the example.