### PR TITLE
consume variables to set username and password otherwise use defaults

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 
 services:
   wg:
@@ -10,6 +10,9 @@ services:
       - EMAIL_FROM
       - EMAIL_FROM_NAME
       - SESSION_SECRET
+      - WGUI_USERNAME=alpha
+      - WGUI_PASSWORD=this-unusual-password
+
     ports:
       - 5000:5000
     logging:

--- a/util/db.go
+++ b/util/db.go
@@ -15,6 +15,8 @@ import (
 )
 
 const dbPath = "./db"
+const username_env_var = "WGUI_USERNAME"
+const password_env_var = "WGUI_PASSWORD"
 const defaultUsername = "admin"
 const defaultPassword = "admin"
 const defaultServerAddress = "10.252.1.0/24"
@@ -31,6 +33,13 @@ func DBConn() (*scribble.Driver, error) {
 		return nil, err
 	}
 	return db, nil
+}
+
+func getCredVar(key, fallback string) string {
+    if value, ok := os.LookupEnv(key); ok {
+		return value
+    }
+    return fallback
 }
 
 // InitDB to create the default database
@@ -112,8 +121,8 @@ func InitDB() error {
 		}
 
 		user := new(model.User)
-		user.Username = defaultUsername
-		user.Password = defaultPassword
+		user.Username = getCredVar(username_env_var, defaultUsername)
+		user.Password = getCredVar(password_env_var, defaultPassword)
 		db.Write("server", "users", user)
 	}
 


### PR DESCRIPTION
This should resolve the request for using env vars to set the username and password of the UI.

If the env var does not exist or has a zero value then it should fall back to defaults.

Note: must disable persistent /data volume to test this one thoroughly