### PR TITLE
Fix generating IPv6 address

### DIFF
--- a/handler/routes.go
+++ b/handler/routes.go
@@ -621,7 +621,11 @@ func SuggestIPAllocation(db store.IStore) echo.HandlerFunc {
 					fmt.Sprintf("Cannot suggest ip allocation: failed to get available ip from network %s", cidr),
 				})
 			}
-			suggestedIPs = append(suggestedIPs, fmt.Sprintf("%s/32", ip))
+			if (strings.Contains(ip, ":")) {
+				suggestedIPs = append(suggestedIPs, fmt.Sprintf("%s/128", ip))
+			} else {
+				suggestedIPs = append(suggestedIPs, fmt.Sprintf("%s/32", ip))
+			}
 		}
 
 		return c.JSON(http.StatusOK, suggestedIPs)


### PR DESCRIPTION
Hi,

generating new IPv6 address is incorrect - it does not check IP version. Correct IPv6 address in this case is /128 netmask, not /32.

Please merge or rewrite to fix this bug :)

Thanks, Lukas