### PR TITLE
attempted fix at template to allow passing extra allowed subnets

### DIFF
--- a/handler/routes.go
+++ b/handler/routes.go
@@ -280,7 +280,7 @@ func UpdateClient(db store.IStore) echo.HandlerFunc {
 			return c.JSON(http.StatusBadRequest, jsonHTTPResponse{false, "Allowed IPs must be in CIDR format"})
 		}
 
-        if len(_client.ExtraAllowedIPs) > 0 && util.ValidateAllowedIPs(_client.ExtraAllowedIPs) == false {
+        if util.ValidateAllowedIPs(_client.ExtraAllowedIPs) == false {
             log.Warnf("Invalid Allowed IPs input from user: %v", _client.ExtraAllowedIPs)
             return c.JSON(http.StatusBadRequest, jsonHTTPResponse{false, "Extra Allowed IPs must be in CIDR format"})
         }

--- a/handler/routes.go
+++ b/handler/routes.go
@@ -162,8 +162,8 @@ func NewClient(db store.IStore) echo.HandlerFunc {
 
 		// validate extra AllowedIPs
 		if util.ValidateAllowedIPs(client.ExtraAllowedIPs) == false {
-		    log.Warnf("Invalid Extra AllowedIPs input from user: %v", client.ExtraAllowedIPs)
-		    return c.JSON(http.StatusBadRequest, jsonHTTPResponse{false, "Extra AllowedIPs must be in CIDR format"})
+			log.Warnf("Invalid Extra AllowedIPs input from user: %v", client.ExtraAllowedIPs)
+			return c.JSON(http.StatusBadRequest, jsonHTTPResponse{false, "Extra AllowedIPs must be in CIDR format"})
 		}
 
 		// gen ID
@@ -280,10 +280,10 @@ func UpdateClient(db store.IStore) echo.HandlerFunc {
 			return c.JSON(http.StatusBadRequest, jsonHTTPResponse{false, "Allowed IPs must be in CIDR format"})
 		}
 
-        if util.ValidateAllowedIPs(_client.ExtraAllowedIPs) == false {
-            log.Warnf("Invalid Allowed IPs input from user: %v", _client.ExtraAllowedIPs)
-            return c.JSON(http.StatusBadRequest, jsonHTTPResponse{false, "Extra Allowed IPs must be in CIDR format"})
-        }
+		if util.ValidateExtraAllowedIPs(_client.ExtraAllowedIPs) == false {
+			log.Warnf("Invalid Allowed IPs input from user: %v", _client.ExtraAllowedIPs)
+			return c.JSON(http.StatusBadRequest, jsonHTTPResponse{false, "Extra Allowed IPs must be in CIDR format"})
+		}
 
 		// map new data
 		client.Name = _client.Name
@@ -640,7 +640,7 @@ func SuggestIPAllocation(db store.IStore) echo.HandlerFunc {
 					fmt.Sprintf("Cannot suggest ip allocation: failed to get available ip from network %s", cidr),
 				})
 			}
-			if (strings.Contains(ip, ":")) {
+			if strings.Contains(ip, ":") {
 				suggestedIPs = append(suggestedIPs, fmt.Sprintf("%s/128", ip))
 			} else {
 				suggestedIPs = append(suggestedIPs, fmt.Sprintf("%s/32", ip))

--- a/handler/routes.go
+++ b/handler/routes.go
@@ -161,7 +161,7 @@ func NewClient(db store.IStore) echo.HandlerFunc {
 		}
 
 		// validate extra AllowedIPs
-		if util.ValidateAllowedIPs(client.ExtraAllowedIPs) == false {
+		if util.ValidateExtraAllowedIPs(client.ExtraAllowedIPs) == false {
 			log.Warnf("Invalid Extra AllowedIPs input from user: %v", client.ExtraAllowedIPs)
 			return c.JSON(http.StatusBadRequest, jsonHTTPResponse{false, "Extra AllowedIPs must be in CIDR format"})
 		}

--- a/handler/routes.go
+++ b/handler/routes.go
@@ -160,6 +160,12 @@ func NewClient(db store.IStore) echo.HandlerFunc {
 			return c.JSON(http.StatusBadRequest, jsonHTTPResponse{false, "Allowed IPs must be in CIDR format"})
 		}
 
+		// validate extra AllowedIPs
+		if util.ValidateAllowedIPs(client.ExtraAllowedIPs) == false {
+		    log.Warnf("Invalid Extra AllowedIPs input from user: %v", client.ExtraAllowedIPs)
+		    return c.JSON(http.StatusBadRequest, jsonHTTPResponse{false, "Extra AllowedIPs must be in CIDR format"})
+		}
+
 		// gen ID
 		guid := xid.New()
 		client.ID = guid.String()
@@ -274,6 +280,13 @@ func UpdateClient(db store.IStore) echo.HandlerFunc {
 			return c.JSON(http.StatusBadRequest, jsonHTTPResponse{false, "Allowed IPs must be in CIDR format"})
 		}
 
+        log.Infof("array length: %d", len(_client.ExtraAllowedIPs) )
+        log.Infof("extraAllowedIPs: %v", _client.ExtraAllowedIPs)
+        if len(_client.ExtraAllowedIPs) > 0 && util.ValidateAllowedIPs(_client.ExtraAllowedIPs) == false {
+            log.Warnf("Invalid Allowed IPs input from user: %v", _client.ExtraAllowedIPs)
+            return c.JSON(http.StatusBadRequest, jsonHTTPResponse{false, "Extra Allowed IPs must be in CIDR format"})
+        }
+
 		// map new data
 		client.Name = _client.Name
 		client.Email = _client.Email
@@ -281,6 +294,7 @@ func UpdateClient(db store.IStore) echo.HandlerFunc {
 		client.UseServerDNS = _client.UseServerDNS
 		client.AllocatedIPs = _client.AllocatedIPs
 		client.AllowedIPs = _client.AllowedIPs
+		client.ExtraAllowedIPs = _client.ExtraAllowedIPs
 		client.UpdatedAt = time.Now().UTC()
 
 		// write to the database

--- a/handler/routes.go
+++ b/handler/routes.go
@@ -280,8 +280,6 @@ func UpdateClient(db store.IStore) echo.HandlerFunc {
 			return c.JSON(http.StatusBadRequest, jsonHTTPResponse{false, "Allowed IPs must be in CIDR format"})
 		}
 
-        log.Infof("array length: %d", len(_client.ExtraAllowedIPs) )
-        log.Infof("extraAllowedIPs: %v", _client.ExtraAllowedIPs)
         if len(_client.ExtraAllowedIPs) > 0 && util.ValidateAllowedIPs(_client.ExtraAllowedIPs) == false {
             log.Warnf("Invalid Allowed IPs input from user: %v", _client.ExtraAllowedIPs)
             return c.JSON(http.StatusBadRequest, jsonHTTPResponse{false, "Extra Allowed IPs must be in CIDR format"})

--- a/model/client.go
+++ b/model/client.go
@@ -6,18 +6,19 @@ import (
 
 // Client model
 type Client struct {
-	ID           string    `json:"id"`
-	PrivateKey   string    `json:"private_key"`
-	PublicKey    string    `json:"public_key"`
-	PresharedKey string    `json:"preshared_key"`
-	Name         string    `json:"name"`
-	Email        string    `json:"email"`
-	AllocatedIPs []string  `json:"allocated_ips"`
-	AllowedIPs   []string  `json:"allowed_ips"`
-	UseServerDNS bool      `json:"use_server_dns"`
-	Enabled      bool      `json:"enabled"`
-	CreatedAt    time.Time `json:"created_at"`
-	UpdatedAt    time.Time `json:"updated_at"`
+	ID              string    `json:"id"`
+	PrivateKey      string    `json:"private_key"`
+	PublicKey       string    `json:"public_key"`
+	PresharedKey    string    `json:"preshared_key"`
+	Name            string    `json:"name"`
+	Email           string    `json:"email"`
+	AllocatedIPs    []string  `json:"allocated_ips"`
+	AllowedIPs      []string  `json:"allowed_ips"`
+	ExtraAllowedIPs []string  `json:"extra_allowed_ips"`
+	UseServerDNS    bool      `json:"use_server_dns"`
+	Enabled         bool      `json:"enabled"`
+	CreatedAt       time.Time `json:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at"`
 }
 
 // ClientData includes the Client and extra data

--- a/templates/base.html
+++ b/templates/base.html
@@ -298,6 +298,12 @@
             const allocated_ips = $("#client_allocated_ips").val().split(",");
             const allowed_ips = $("#client_allowed_ips").val().split(",");
             let use_server_dns = false;
+            let extra_allowed_ips = [];
+
+            if ($("#client_extra_allowed_ips").val() !== "") {
+                extra_allowed_ips = $("#client_extra_allowed_ips").val().split(",");
+            }
+
 
             if ($("#use_server_dns").is(':checked')){
                 use_server_dns = true;
@@ -310,7 +316,7 @@
             }
 
             const data = {"name": name, "email": email, "allocated_ips": allocated_ips, "allowed_ips": allowed_ips,
-                "use_server_dns": use_server_dns, "enabled": enabled};
+                "extra_allowed_ips": extra_allowed_ips, "use_server_dns": use_server_dns, "enabled": enabled};
 
             $.ajax({
                 cache: false,

--- a/templates/base.html
+++ b/templates/base.html
@@ -164,6 +164,11 @@
                                     value="0.0.0.0/0">
                             </div>
                             <div class="form-group">
+                                <label for="client_extra_allowed_ips" class="control-label">Extra Allowed IPs</label>
+                                <input type="text" data-role="tagsinput" class="form-control"
+                                     id="client_extra_allowed_ips">
+                            </div>
+                            <div class="form-group">
                                 <div class="icheck-primary d-inline">
                                     <input type="checkbox" id="use_server_dns" checked>
                                     <label for="use_server_dns">
@@ -376,6 +381,16 @@
             'placeholderColor': '#666666'
         });
 
+        $("#client_extra_allowed_ips").tagsInput({
+            'width': '100%',
+            'height': '75%',
+            'interactive': true,
+            'defaultText': 'Add More',
+            'removeWithBackspace': true,
+            'minChars': 0,
+            'placeholderColor': '#666666'
+        });
+
         // New client form validation
         $(document).ready(function () {
             $.validator.setDefaults({
@@ -414,6 +429,7 @@
                 $("#client_name").val("");
                 $("#client_email").val("");
                 $("#client_allocated_ips").importTags('');
+                $("#client_extra_allowed_ips").importTags('');
                 updateIPAllocationSuggestion();
             });
         });

--- a/templates/clients.html
+++ b/templates/clients.html
@@ -87,6 +87,11 @@ Wireguard Clients
                         <input type="text" data-role="tagsinput" class="form-control" id="_client_allowed_ips">
                     </div>
                     <div class="form-group">
+                        <label for="_client_extra_allowed_ips" class="control-label">Extra Allowed IPs</label>
+                        <input type="text" data-role="tagsinput" class="form-control"
+                               id="_client_extra_allowed_ips">
+                    </div>
+                    <div class="form-group">
                         <div class="icheck-primary d-inline">
                             <input type="checkbox" id="_use_server_dns">
                             <label for="_use_server_dns">
@@ -302,6 +307,16 @@ Wireguard Clients
                     'placeholderColor': '#666666'
                 });
 
+                modal.find("#_client_extra_allowed_ips").tagsInput({
+                    'width': '100%',
+                    'height': '75%',
+                    'interactive': true,
+                    'defaultText': 'Add More',
+                    'removeWithBackspace' : true,
+                    'minChars': 0,
+                    'placeholderColor': '#666666'
+                })
+
                 // update client modal data
                 $.ajax({
                     cache: false,
@@ -325,6 +340,11 @@ Wireguard Clients
                         modal.find("#_client_allowed_ips").importTags('');
                         client.allowed_ips.forEach(function (obj) {
                             modal.find("#_client_allowed_ips").addTag(obj);
+                        });
+
+                        modal.find("#_client_extra_allowed_ips").importTags('');
+                        client.extra_allowed_ips.forEach(function (obj) {
+                            modal.find("#_client_extra_allowed_ips").addTag(obj);
                         });
 
                         modal.find("#_use_server_dns").prop("checked", client.use_server_dns);
@@ -370,6 +390,7 @@ Wireguard Clients
             const email = $("#_client_email").val();
             const allocated_ips = $("#_client_allocated_ips").val().split(",");
             const allowed_ips = $("#_client_allowed_ips").val().split(",");
+            const extra_allowed_ips = $("#_client_extra_allowed_ips").val().split(",");
             let use_server_dns = false;
 
             if ($("#_use_server_dns").is(':checked')){
@@ -383,7 +404,7 @@ Wireguard Clients
             }
 
             const data = {"id": client_id, "name": name, "email": email, "allocated_ips": allocated_ips,
-                "allowed_ips": allowed_ips, "use_server_dns": use_server_dns, "enabled": enabled};
+                "allowed_ips": allowed_ips, "extra_allowed_ips": extra_allowed_ips, "use_server_dns": use_server_dns, "enabled": enabled};
 
             $.ajax({
                 cache: false,

--- a/templates/clients.html
+++ b/templates/clients.html
@@ -390,8 +390,12 @@ Wireguard Clients
             const email = $("#_client_email").val();
             const allocated_ips = $("#_client_allocated_ips").val().split(",");
             const allowed_ips = $("#_client_allowed_ips").val().split(",");
-            const extra_allowed_ips = $("#_client_extra_allowed_ips").val().split(",");
             let use_server_dns = false;
+            let extra_allowed_ips = [];
+
+            if( $("#_client_extra_allowed_ips").val() !== "" ) {
+                extra_allowed_ips = $("#_client_extra_allowed_ips").val().split(",");
+            }
 
             if ($("#_use_server_dns").is(':checked')){
                 use_server_dns = true;

--- a/templates/wg.conf
+++ b/templates/wg.conf
@@ -20,5 +20,5 @@ PostDown = {{ .serverConfig.Interface.PostDown }}
 [Peer]
 PublicKey = {{ .Client.PublicKey }}
 PresharedKey = {{ .Client.PresharedKey }}
-AllowedIPs = {{$first :=true}}{{range .Client.AllocatedIPs }}{{if $first}}{{$first = false}}{{else}},{{end}}{{.}}{{end}}{{$first :=true}}{{range .Client.AllowedIPs }}{{if ne . "0.0.0.0/0" }},{{.}}{{end}}{{end}}
+AllowedIPs = {{$first :=true}}{{range .Client.AllocatedIPs }}{{if $first}}{{$first = false}}{{else}},{{end}}{{.}}{{end}}{{$first :=true}}{{range .Client.ExtraAllowedIPs }},{{.}}{{end}}
 {{end}}{{end}}

--- a/templates/wg.conf
+++ b/templates/wg.conf
@@ -20,5 +20,5 @@ PostDown = {{ .serverConfig.Interface.PostDown }}
 [Peer]
 PublicKey = {{ .Client.PublicKey }}
 PresharedKey = {{ .Client.PresharedKey }}
-AllowedIPs = {{$first :=true}}{{range .Client.AllocatedIPs }}{{if $first}}{{$first = false}}{{else}},{{end}}{{.}}{{end}}{{range .Client.ExtraAllowedIPs }}{{if ne . ""}},{{.}}{{else}}{{end}}{{end}}
+AllowedIPs = {{$first :=true}}{{range .Client.AllocatedIPs }}{{if $first}}{{$first = false}}{{else}},{{end}}{{.}}{{end}}{{range .Client.ExtraAllowedIPs }},{{.}}{{end}}
 {{end}}{{end}}

--- a/templates/wg.conf
+++ b/templates/wg.conf
@@ -20,5 +20,5 @@ PostDown = {{ .serverConfig.Interface.PostDown }}
 [Peer]
 PublicKey = {{ .Client.PublicKey }}
 PresharedKey = {{ .Client.PresharedKey }}
-AllowedIPs = {{$first :=true}}{{range .Client.AllocatedIPs }}{{if $first}}{{$first = false}}{{else}},{{end}}{{.}}{{end}}
+AllowedIPs = {{$first :=true}}{{range .Client.AllocatedIPs }}{{if $first}}{{$first = false}}{{else}},{{end}}{{.}}{{end}}{{$first :=true}}{{range .Client.AllowedIPs }}{{if ne . "0.0.0.0/0" }},{{.}}{{end}}{{end}}
 {{end}}{{end}}

--- a/templates/wg.conf
+++ b/templates/wg.conf
@@ -20,5 +20,5 @@ PostDown = {{ .serverConfig.Interface.PostDown }}
 [Peer]
 PublicKey = {{ .Client.PublicKey }}
 PresharedKey = {{ .Client.PresharedKey }}
-AllowedIPs = {{$first :=true}}{{range .Client.AllocatedIPs }}{{if $first}}{{$first = false}}{{else}},{{end}}{{.}}{{end}}{{$first :=true}}{{range .Client.ExtraAllowedIPs }},{{.}}{{end}}
+AllowedIPs = {{$first :=true}}{{range .Client.AllocatedIPs }}{{if $first}}{{$first = false}}{{else}},{{end}}{{.}}{{end}}{{range .Client.ExtraAllowedIPs }}{{if ne . ""}},{{.}}{{else}}{{end}}{{end}}
 {{end}}{{end}}

--- a/util/util.go
+++ b/util/util.go
@@ -76,12 +76,18 @@ func ValidateCIDR(cidr string) bool {
 }
 
 // ValidateCIDRList to validate a list of network CIDR
-func ValidateCIDRList(cidrs []string) bool {
+func ValidateCIDRList(cidrs []string, allowEmpty bool) bool {
 	for _, cidr := range cidrs {
-	    if len(cidr) > 0 {
-            if ValidateCIDR(cidr) == false {
-                return false
-            }
+		if allowEmpty {
+			if len(cidr) > 0 {
+				if ValidateCIDR(cidr) == false {
+					return false
+				}
+			}
+		} else {
+			if ValidateCIDR(cidr) == false {
+				return false
+			}
 		}
 	}
 	return true
@@ -89,7 +95,15 @@ func ValidateCIDRList(cidrs []string) bool {
 
 // ValidateAllowedIPs to validate allowed ip addresses in CIDR format
 func ValidateAllowedIPs(cidrs []string) bool {
-	if ValidateCIDRList(cidrs) == false {
+	if ValidateCIDRList(cidrs, false) == false {
+		return false
+	}
+	return true
+}
+
+// ValidateExtraAllowedIPs to validate extra Allowed ip addresses, allowing empty strings
+func ValidateExtraAllowedIPs(cidrs []string) bool {
+	if ValidateCIDRList(cidrs, true) == false {
 		return false
 	}
 	return true
@@ -97,7 +111,7 @@ func ValidateAllowedIPs(cidrs []string) bool {
 
 // ValidateServerAddresses to validate allowed ip addresses in CIDR format
 func ValidateServerAddresses(cidrs []string) bool {
-	if ValidateCIDRList(cidrs) == false {
+	if ValidateCIDRList(cidrs, false) == false {
 		return false
 	}
 	return true

--- a/util/util.go
+++ b/util/util.go
@@ -78,8 +78,10 @@ func ValidateCIDR(cidr string) bool {
 // ValidateCIDRList to validate a list of network CIDR
 func ValidateCIDRList(cidrs []string) bool {
 	for _, cidr := range cidrs {
-		if ValidateCIDR(cidr) == false {
-			return false
+	    if len(cidr) > 0 {
+            if ValidateCIDR(cidr) == false {
+                return false
+            }
 		}
 	}
 	return true


### PR DESCRIPTION
I have a hub-and-spoke Wireguard server where I have several endpoints, each providing a subnet to my Wireguard server. This PR enables setting AllowedIPs from client side to be written to the server's wg0.conf. Tested successfully.