### PR TITLE
Fix flag to disable login

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,6 +43,7 @@ const (
 func init() {
 
 	// command-line flags and env variables
+	flag.BoolVar(&flagDisableLogin, "disable-login", util.LookupEnvOrBool("DISABLE_LOGIN", flagDisableLogin), "Disable authentication on the app. This is potentially dangerous.")
 	flag.StringVar(&flagBindAddress, "bind-address", util.LookupEnvOrString("BIND_ADDRESS", flagBindAddress), "Address:Port to which the app will be bound.")
 	flag.StringVar(&flagSendgridApiKey, "sendgrid-api-key", util.LookupEnvOrString("SENDGRID_API_KEY", flagSendgridApiKey), "Your sendgrid api key.")
 	flag.StringVar(&flagEmailFrom, "email-from", util.LookupEnvOrString("EMAIL_FROM_ADDRESS", flagEmailFrom), "'From' email address.")

--- a/util/util.go
+++ b/util/util.go
@@ -380,7 +380,7 @@ func LookupEnvOrBool(key string, defaultVal bool) bool {
 	if val, ok := os.LookupEnv(key); ok {
 		v, err := strconv.ParseBool(val)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "LookupEnvOrInt[%s]: %v\n", key, err)
+			fmt.Fprintf(os.Stderr, "LookupEnvOrBool[%s]: %v\n", key, err)
 		}
 		return v
 	}


### PR DESCRIPTION
It seems the option to disable login was left out of the recent env vars and flags refactor. Also, I think `util.go` had a typo in an error message. I've never worked with Go before, so I hope this is ok.