### PR TITLE
Bring back e-mail button in clients view

### DIFF
--- a/custom/js/helper.js
+++ b/custom/js/helper.js
@@ -29,6 +29,9 @@ function renderClientList(data) {
                                 <div class="btn-group">
                                     <a href="/download?clientid=${obj.Client.id}"
                                         class="btn btn-outline-success btn-sm">Download</a>
+                                    <button type="button" class="btn btn-outline-warning btn-sm" data-toggle="modal"
+                                        data-target="#modal_email_client" data-clientid="${obj.Client.id}"
+                                        data-clientname="${obj.Client.name}">Email</button>
                                     <button type="button" class="btn btn-outline-primary btn-sm" data-toggle="modal"
                                         data-target="#modal_edit_client" data-clientid="${obj.Client.id}"
                                         data-clientname="${obj.Client.name}">Edit</button>

--- a/templates/login.html
+++ b/templates/login.html
@@ -91,6 +91,11 @@
 </script>
 <script>
     $(document).ready(function () {
+        $('form').on('submit', function(e) {
+            e.preventDefault();
+            $("#btn_login").trigger('click');
+        });
+
         $("#btn_login").click(function () {
             const username = $("#username").val();
             const password = $("#password").val();


### PR DESCRIPTION
Bring back e-mail button, triggers e-mail modal to show.

Looks like removed on commit: https://github.com/ngoduykhanh/wireguard-ui/commit/93e3e847f2b52f295c91a45968924eb17a75f5fc