### PR TITLE
PresharedKey is now only included if set

### DIFF
--- a/templates/wg.conf
+++ b/templates/wg.conf
@@ -19,6 +19,6 @@ PostDown = {{ .serverConfig.Interface.PostDown }}
 # Update at:    {{ .Client.UpdatedAt }}
 [Peer]
 PublicKey = {{ .Client.PublicKey }}
-PresharedKey = {{ .Client.PresharedKey }}
-AllowedIPs = {{$first :=true}}{{range .Client.AllocatedIPs }}{{if $first}}{{$first = false}}{{else}},{{end}}{{.}}{{end}}
+{{if .Client.PresharedKey }}PresharedKey = {{ .Client.PresharedKey }}
+{{end}}AllowedIPs = {{$first :=true}}{{range .Client.AllocatedIPs }}{{if $first}}{{$first = false}}{{else}},{{end}}{{.}}{{end}}
 {{end}}{{end}}

--- a/util/util.go
+++ b/util/util.go
@@ -21,17 +21,21 @@ import (
 // BuildClientConfig to create wireguard client config string
 func BuildClientConfig(client model.Client, server model.Server, setting model.GlobalSetting) string {
 	// Interface section
-	clientAddress := fmt.Sprintf("Address = %s", strings.Join(client.AllocatedIPs, ","))
-	clientPrivateKey := fmt.Sprintf("PrivateKey = %s", client.PrivateKey)
+	clientAddress := fmt.Sprintf("Address = %s\n", strings.Join(client.AllocatedIPs, ","))
+	clientPrivateKey := fmt.Sprintf("PrivateKey = %s\n", client.PrivateKey)
 	clientDNS := ""
 	if client.UseServerDNS {
-		clientDNS = fmt.Sprintf("DNS = %s", strings.Join(setting.DNSServers, ","))
+		clientDNS = fmt.Sprintf("DNS = %s\n", strings.Join(setting.DNSServers, ","))
 	}
 
 	// Peer section
-	peerPublicKey := fmt.Sprintf("PublicKey = %s", server.KeyPair.PublicKey)
-	peerPresharedKey := fmt.Sprintf("PresharedKey = %s", client.PresharedKey)
-	peerAllowedIPs := fmt.Sprintf("AllowedIPs = %s", strings.Join(client.AllowedIPs, ","))
+	peerPublicKey := fmt.Sprintf("PublicKey = %s\n", server.KeyPair.PublicKey)
+	peerPresharedKey := ""
+	if client.PresharedKey != "" {
+		peerPresharedKey = fmt.Sprintf("PresharedKey = %s\n", client.PresharedKey)
+	}
+
+	peerAllowedIPs := fmt.Sprintf("AllowedIPs = %s\n", strings.Join(client.AllowedIPs, ","))
 
 	desiredHost := setting.EndpointAddress
 	desiredPort := server.Interface.ListenPort
@@ -44,24 +48,24 @@ func BuildClientConfig(client model.Client, server model.Server, setting model.G
 			log.Error("Endpoint appears to be incorrectly formatted: ", err)
 		}
 	}
-	peerEndpoint := fmt.Sprintf("Endpoint = %s:%d", desiredHost, desiredPort)
+	peerEndpoint := fmt.Sprintf("Endpoint = %s:%d\n", desiredHost, desiredPort)
 
 	peerPersistentKeepalive := ""
 	if setting.PersistentKeepalive > 0 {
-		peerPersistentKeepalive = fmt.Sprintf("PersistentKeepalive = %d", setting.PersistentKeepalive)
+		peerPersistentKeepalive = fmt.Sprintf("PersistentKeepalive = %d\n", setting.PersistentKeepalive)
 	}
 
 	// build the config as string
 	strConfig := "[Interface]\n" +
-		clientAddress + "\n" +
-		clientPrivateKey + "\n" +
-		clientDNS + "\n\n" +
-		"[Peer]" + "\n" +
-		peerPublicKey + "\n" +
-		peerPresharedKey + "\n" +
-		peerAllowedIPs + "\n" +
-		peerEndpoint + "\n" +
-		peerPersistentKeepalive + "\n"
+		clientAddress +
+		clientPrivateKey +
+		clientDNS +
+		"\n[Peer]\n" +
+		peerPublicKey +
+		peerPresharedKey +
+		peerAllowedIPs +
+		peerEndpoint +
+		peerPersistentKeepalive
 
 	return strConfig
 }


### PR DESCRIPTION
PresharedKey is now only set in the server and client config if the key
is set and not null (or empty).

I added this feature because I was importing old config files from
clients that did not have a preshared key set. Clients can be created
without preshared keys when editing db/client/ files manually. If the
field is not set, wireguard-ui creates invalid configs by producing:

PresharedKey =

This patch remvoes this behavior and just skips the preshared key if not
set.