### PR TITLE
Add ForwardMark to global settings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ngoduykhanh/wireguard-ui
 go 1.14
 
 require (
-	github.com/GeertJohan/go.rice v1.0.0
+	github.com/GeertJohan/go.rice v1.0.2
 	github.com/glendc/go-external-ip v0.0.0-20170425150139-139229dcdddd
 	github.com/go-playground/universal-translator v0.17.0 // indirect
 	github.com/gorilla/sessions v1.2.0
@@ -13,6 +13,7 @@ require (
 	github.com/labstack/gommon v0.3.0
 	github.com/leodido/go-urn v1.2.0 // indirect
 	github.com/rs/xid v1.2.1
+	github.com/sabhiram/go-wol v0.0.0-20211224004021-c83b0c2f887d
 	github.com/sdomino/scribble v0.0.0-20191024200645-4116320640ba
 	github.com/sendgrid/rest v2.6.4+incompatible // indirect
 	github.com/sendgrid/sendgrid-go v3.10.0+incompatible
@@ -22,5 +23,4 @@ require (
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20210803171230-4253848d036c
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/validator.v9 v9.31.0
-	github.com/sabhiram/go-wol v0.0.0-20211224004021-c83b0c2f887d
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,11 @@
+github.com/GeertJohan/go.incremental v1.0.0 h1:7AH+pY1XUgQE4Y1HcXYaMqAI0m9yrFqo/jt0CW30vsg=
 github.com/GeertJohan/go.incremental v1.0.0/go.mod h1:6fAjUhbVuX1KcMD3c8TEgVUqmo4seqhv0i0kdATSkM0=
 github.com/GeertJohan/go.rice v1.0.0 h1:KkI6O9uMaQU3VEKaj01ulavtF7o1fWT7+pk/4voiMLQ=
 github.com/GeertJohan/go.rice v1.0.0/go.mod h1:eH6gbSOAUv07dQuZVnBmoDP8mgsM1rtixis4Tib9if0=
+github.com/GeertJohan/go.rice v1.0.2 h1:PtRw+Tg3oa3HYwiDBZyvOJ8LdIyf6lAovJJtr7YOAYk=
+github.com/GeertJohan/go.rice v1.0.2/go.mod h1:af5vUNlDNkCjOZeSGFgIJxDje9qdjsO6hshx0gTmZt4=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
+github.com/akavel/rsrc v0.8.0 h1:zjWn7ukO9Kc5Q62DOJCcxGpXC18RawVtYAGdz2aLlfw=
 github.com/akavel/rsrc v0.8.0/go.mod h1:uLoCtb9J+EyAqh+26kdrTgmzRBFPGOolLWKpdxkKq+c=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -51,6 +55,7 @@ github.com/gorilla/sessions v1.2.0/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/z
 github.com/jcelliott/lumber v0.0.0-20160324203708-dd349441af25 h1:EFT6MH3igZK/dIVqgGbTqWVvkZ7wJ5iGN03SVtvvdd8=
 github.com/jcelliott/lumber v0.0.0-20160324203708-dd349441af25/go.mod h1:sWkGw/wsaHtRsT9zGQ/WyJCotGWG/Anow/9hsAcBWRw=
 github.com/jessevdk/go-flags v0.0.0-20150816100521-1acbbaff2f34/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/josharian/native v0.0.0-20200817173448-b6b71def0850 h1:uhL5Gw7BINiiPAo24A2sxkcDI0Jt/sqp1v5xQCniEFA=
 github.com/josharian/native v0.0.0-20200817173448-b6b71def0850/go.mod h1:7X/raswPFr05uY3HiLlYeyQntB6OO7E/d2Cu7qoaN2w=
@@ -106,6 +111,8 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nkovacs/streamquote v0.0.0-20170412213628-49af9bddb229/go.mod h1:0aYXnNPJ8l7uZxf45rWW1a/uME32OF0rhiYGNQ2oF2E=
+github.com/nkovacs/streamquote v1.0.0 h1:PmVIV08Zlx2lZK5fFZlMZ04eHcDTIFJCv/5/0twVUow=
+github.com/nkovacs/streamquote v1.0.0/go.mod h1:BN+NaZ2CmdKqUuTUXUEm9j95B2TRbpOWpxbJYzzgUsc=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/model/setting.go
+++ b/model/setting.go
@@ -10,6 +10,7 @@ type GlobalSetting struct {
 	DNSServers          []string  `json:"dns_servers"`
 	MTU                 int       `json:"mtu,string"`
 	PersistentKeepalive int       `json:"persistent_keepalive,string"`
+	ForwardMark         string    `json:"forward_mark"`
 	ConfigFilePath      string    `json:"config_file_path"`
 	UpdatedAt           time.Time `json:"updated_at"`
 }

--- a/store/jsondb/jsondb.go
+++ b/store/jsondb/jsondb.go
@@ -90,6 +90,7 @@ func (o *JsonDB) Init() error {
 		globalSetting.DNSServers = []string{util.DefaultDNS}
 		globalSetting.MTU = util.DefaultMTU
 		globalSetting.PersistentKeepalive = util.DefaultPersistentKeepalive
+		globalSetting.ForwardMark = util.DefaultForwardMark
 		globalSetting.ConfigFilePath = util.DefaultConfigFilePath
 		globalSetting.UpdatedAt = time.Now().UTC()
 		o.conn.Write("server", "global_settings", globalSetting)

--- a/templates/global_settings.html
+++ b/templates/global_settings.html
@@ -56,6 +56,12 @@ Global Settings
                                     value="{{if .globalSettings.PersistentKeepalive }}{{ .globalSettings.PersistentKeepalive }}{{end}}">
                             </div>
                             <div class="form-group">
+                                <label for="forward_mark">Forward Mark</label>
+                                <input type="text" class="form-control" id="forward_mark"
+                                    name="forward_mark" placeholder="Forward Mark"
+                                    value="{{ .globalSettings.ForwardMark }}">
+                            </div>
+                            <div class="form-group">
                                 <label for="config_file_path">Wireguard Config File Path</label>
                                 <input type="text" class="form-control" id="config_file_path"
                                     name="config_file_path" placeholder="E.g. /etc/wireguard/wg0.conf"
@@ -141,8 +147,9 @@ Global Settings
             const dns_servers = $("#dns_servers").val().split(",");
             const mtu = $("#mtu").val();
             const persistent_keepalive = $("#persistent_keepalive").val();
+            const forward_mark = $("#forward_mark").val();
             const config_file_path = $("#config_file_path").val();
-            const data = {"endpoint_address": endpoint_address, "dns_servers": dns_servers, "mtu": mtu, "persistent_keepalive": persistent_keepalive, "config_file_path": config_file_path};
+            const data = {"endpoint_address": endpoint_address, "dns_servers": dns_servers, "mtu": mtu, "persistent_keepalive": persistent_keepalive, "forward_mark": forward_mark, "config_file_path": config_file_path};
 
             $.ajax({
                 cache: false,
@@ -211,6 +218,9 @@ Global Settings
                     },
                     config_file_path: {
                         required: true
+                    },
+                    forward_mark: {
+                        required: false
                     }
                 },
                 messages: {

--- a/util/config.go
+++ b/util/config.go
@@ -26,6 +26,7 @@ const (
 	DefaultDNS                 = "1.1.1.1"
 	DefaultMTU                 = 1450
 	DefaultPersistentKeepalive = 15
+	DefaultForwardMark         = "0xca6c"
 	DefaultConfigFilePath      = "/etc/wireguard/wg0.conf"
 	UsernameEnvVar             = "WGUI_USERNAME"
 	PasswordEnvVar             = "WGUI_PASSWORD"

--- a/util/util.go
+++ b/util/util.go
@@ -55,11 +55,17 @@ func BuildClientConfig(client model.Client, server model.Server, setting model.G
 		peerPersistentKeepalive = fmt.Sprintf("PersistentKeepalive = %d\n", setting.PersistentKeepalive)
 	}
 
+	forwardMark := ""
+	if setting.ForwardMark != DefaultForwardMark {
+		forwardMark = fmt.Sprintf("FwMark = %s\n", setting.ForwardMark)
+	}
+
 	// build the config as string
 	strConfig := "[Interface]\n" +
 		clientAddress +
 		clientPrivateKey +
 		clientDNS +
+		forwardMark +
 		"\n[Peer]\n" +
 		peerPublicKey +
 		peerPresharedKey +


### PR DESCRIPTION
I had to set the `FwMark` to sovle my network conflict running k3s and wireguard on the same host.

[Network Conflict k3s and wireguard](https://lists.zx2c4.com/pipermail/wireguard/2020-September/005849.html)