### PR TITLE
Adding Flags and form for email templating

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,9 +3,10 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/labstack/echo/v4"
 	"net/http"
 	"time"
+
+	"github.com/labstack/echo/v4"
 
 	rice "github.com/GeertJohan/go.rice"
 	"github.com/ngoduykhanh/wireguard-ui/emailer"
@@ -34,6 +35,8 @@ var (
 	flagEmailFrom      string
 	flagEmailFromName  string = "WireGuard UI"
 	flagSessionSecret  string
+	flagClientMTU      int
+	flagAllowedIPs     string
 )
 
 const (
@@ -60,6 +63,8 @@ func init() {
 	flag.StringVar(&flagEmailFrom, "email-from", util.LookupEnvOrString("EMAIL_FROM_ADDRESS", flagEmailFrom), "'From' email address.")
 	flag.StringVar(&flagEmailFromName, "email-from-name", util.LookupEnvOrString("EMAIL_FROM_NAME", flagEmailFromName), "'From' email name.")
 	flag.StringVar(&flagSessionSecret, "session-secret", util.LookupEnvOrString("SESSION_SECRET", flagSessionSecret), "The key used to encrypt session cookies.")
+	flag.IntVar(&flagClientMTU, "client-mtu", util.LookupEnvOrInt("CLIENT_MTU", flagClientMTU), "Client default MTU")
+	flag.StringVar(&flagAllowedIPs, "allowed-ips", util.LookupEnvOrString("ALLOWED_IPS", flagAllowedIPs), "List of default allowed IPs for the client")
 	flag.Parse()
 
 	// update runtime config
@@ -75,6 +80,8 @@ func init() {
 	util.EmailFrom = flagEmailFrom
 	util.EmailFromName = flagEmailFromName
 	util.SessionSecret = []byte(flagSessionSecret)
+	util.ClientMTU = flagClientMTU
+	util.AllowedIPs = flagAllowedIPs
 
 	// print app information
 	fmt.Println("Wireguard UI")

--- a/model/misc.go
+++ b/model/misc.go
@@ -10,4 +10,5 @@ type Interface struct {
 type BaseData struct {
 	Active      string
 	CurrentUser string
+	AllowedIPs  string
 }

--- a/model/setting.go
+++ b/model/setting.go
@@ -11,5 +11,7 @@ type GlobalSetting struct {
 	MTU                 int       `json:"mtu,string"`
 	PersistentKeepalive int       `json:"persistent_keepalive,string"`
 	ConfigFilePath      string    `json:"config_file_path"`
+	EmailSubject        string    `json:"email_subject"`
+	EmailContent        string    `json:"email_content"`
 	UpdatedAt           time.Time `json:"updated_at"`
 }

--- a/store/jsondb/jsondb.go
+++ b/store/jsondb/jsondb.go
@@ -115,7 +115,18 @@ func (o *JsonDB) GetUser() (model.User, error) {
 // GetGlobalSettings func to query global settings from the database
 func (o *JsonDB) GetGlobalSettings() (model.GlobalSetting, error) {
 	settings := model.GlobalSetting{}
-	return settings, o.conn.Read("server", "global_settings", &settings)
+	err := o.conn.Read("server", "global_settings", &settings)
+	if err != nil {
+		return settings, err
+	}
+	if settings.EmailContent != "" {
+		str, err := base64.StdEncoding.DecodeString(settings.EmailContent)
+		if err != nil {
+			return settings, err
+		}
+		settings.EmailContent = string(str)
+	}
+	return settings, err
 }
 
 // GetServer func to query Server setting from the database

--- a/templates/base.html
+++ b/templates/base.html
@@ -175,7 +175,7 @@
                                     </i>
                                 </label>
                                 <input type="text" data-role="tagsinput" class="form-control" id="client_allowed_ips"
-                                    value="0.0.0.0/0">
+                                    value="{{if .baseData.AllowedIPs}} {{.baseData.AllowedIPs}} {{else}} 0.0.0.0/0 {{end}}">
                             </div>
                             <div class="form-group">
                                 <label for="client_extra_allowed_ips" class="control-label">Extra Allowed IPs

--- a/templates/global_settings.html
+++ b/templates/global_settings.html
@@ -61,6 +61,16 @@ Global Settings
                                     name="config_file_path" placeholder="E.g. /etc/wireguard/wg0.conf"
                                     value="{{ .globalSettings.ConfigFilePath }}">
                             </div>
+                            <div class="form-group">
+                                <label for="email_subject">Email Subject</label>
+                                <input type="text" class="form-control" id="email_subject"
+                                    name="email_subject" placeholder="Your new wireguard configuration"
+                                    value="{{ .globalSettings.EmailSubject }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="email_content">Email Content</label>
+                                <textarea class="form-control" id="email_content" name="email_content" placeholder="<p>Html email template</p>" rows="3"> {{ .globalSettings.EmailContent }} </textarea>
+                            </div>
                         </div>
                         <!-- /.card-body -->
 
@@ -142,7 +152,17 @@ Global Settings
             const mtu = $("#mtu").val();
             const persistent_keepalive = $("#persistent_keepalive").val();
             const config_file_path = $("#config_file_path").val();
-            const data = {"endpoint_address": endpoint_address, "dns_servers": dns_servers, "mtu": mtu, "persistent_keepalive": persistent_keepalive, "config_file_path": config_file_path};
+            const email_subject = $("#email_subject").val();
+            const email_content = $("#email_content").val();
+            const data = {
+              "endpoint_address": endpoint_address,
+              "dns_servers": dns_servers,
+              "mtu": mtu,
+              "persistent_keepalive": persistent_keepalive,
+              "config_file_path": config_file_path,
+              "email_subject": email_subject,
+              "email_content": email_content
+            };
 
             $.ajax({
                 cache: false,

--- a/util/config.go
+++ b/util/config.go
@@ -16,6 +16,8 @@ var (
 	EmailSubject   string
 	EmailContent   string
 	SessionSecret  []byte
+	ClientMTU      int
+	AllowedIPs     string
 )
 
 const (

--- a/util/util.go
+++ b/util/util.go
@@ -27,6 +27,10 @@ func BuildClientConfig(client model.Client, server model.Server, setting model.G
 	if client.UseServerDNS {
 		clientDNS = fmt.Sprintf("DNS = %s\n", strings.Join(setting.DNSServers, ","))
 	}
+	clientMTU := ""
+	if ClientMTU > 0 {
+		clientMTU = fmt.Sprintf("MTU =  %d\n", ClientMTU)
+	}
 
 	// Peer section
 	peerPublicKey := fmt.Sprintf("PublicKey = %s\n", server.KeyPair.PublicKey)
@@ -60,6 +64,7 @@ func BuildClientConfig(client model.Client, server model.Server, setting model.G
 		clientAddress +
 		clientPrivateKey +
 		clientDNS +
+		clientMTU +
 		"\n[Peer]\n" +
 		peerPublicKey +
 		peerPresharedKey +


### PR DESCRIPTION
Hello, 

This pull request add two new flag:

- allowed-ips: Which allow you to set a list of allowed IP that will be added automatically to any new client 
- client-mtu: Settings a default MTU on the client side (some service like google chat need a specific MTU to be enforce on the client side)

Also I took the liberty to add the Email Template Subject and Content on the Global Settings Form page saving them in the global_settings.json file (it will use the default values if not set)
Regarding the email content I save it in base 64 so I don't have any conflict with the json format.

Cheers

