### PR TITLE
Add environment variables for configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,40 @@ wireguard interface stats. See the `cap_add` and `network_mode` options on the d
 
 ### Environment Variables
 
+| Variable                    | Description                                                                                         |
+|-----------------------------|-----------------------------------------------------------------------------------------------------|
+| `SESSION_SECRET`            | Used to encrypt the session cookies. Set this to a random value.                                    |
+| `WGUI_USERNAME`             | The username for the login page. (default `admin`)                                                  |
+| `WGUI_PASSWORD`             | The password for the user on the login page. (default `admin`)                                      |
+| `WGUI_DNS`                  | The default DNS servers (comma-separated-list) used in the global settings. (default `1.1.1.1`)     |
+| `WGUI_MTU`                  | The default MTU used in global settings. (default `1450`)                                           |
+| `WGUI_PERSISTENT_KEEPALIVE` | The default persistent keepalive for WireGuard in global settings. (default `15`)                   |
+| `WGUI_FORWARD_MARK`         | The default WireGuard forward mark. (default `0xca6c`)                                              |
+| `WGUI_CONFIG_FILE_PATH`     | The default WireGuard config file path used in global settings. (default `/etc/wireguard/wg0.conf`) |
 
-Set the `SESSION_SECRET` environment variable to a random value.
+#### Defaults for server configuration
+
+These environment variables are used to control the default server settings used when initializing the database.
+
+| Variable                          | Description                                                                                                              |
+|-----------------------------------|--------------------------------------------------------------------------------------------------------------------------|
+| `WGUI_SERVER_INTERFACE_ADDRESSES` | The default interface addresses (comma-separated-list) for the WireGuard server configuration. (default `10.252.1.0/24`) |
+| `WGUI_SERVER_LISTEN_PORT`         | The default server listen port. (default `51820`)                                                                        |
+| `WGUI_SERVER_POST_UP_SCRIPT`      | The default server post-up script.                                                                                       |
+| `WGUI_SERVER_POST_DOWN_SCRIPT`    | The default server post-down script.                                                                                     |
+
+#### Defaults for new clients
+
+These environment variables are used to set the defaults used in `New Client` dialog.
+
+| Variable                                    | Description                                                                                                      |
+|---------------------------------------------|------------------------------------------------------------------------------------------------------------------|
+| `WGUI_DEFAULT_CLIENT_ALLOWED_IPS`           | Comma-separated-list of CIDRs for the `Allowed IPs` field. (default `0.0.0.0/0`)                                 |
+| `WGUI_DEFAULT_CLIENT_EXTRA_ALLOWED_IPS`     | Comma-separated-list of CIDRs for the `Extra Allowed IPs` field. (default empty)                                 |
+| `WGUI_DEFAULT_CLIENT_USE_SERVER_DNS`        | Boolean value [`0`, `f`, `F`, `false`, `False`, `FALSE`, `1`, `t`, `T`, `true`, `True`, `TRUE`] (default `true`) |
+| `WGUI_DEFAULT_CLIENT_ENABLE_AFTER_CREATION` | Boolean value [`0`, `f`, `F`, `false`, `False`, `FALSE`, `1`, `t`, `T`, `true`, `True`, `TRUE`] (default `true`) |
+
+#### Email configuration
 
 To use custom `wg.conf` template set the `WG_CONF_TEMPLATE` environment variable to a path to such file. Make sure `wireguard-ui` will be able to work with it - use [default template](templates/wg.conf) for reference.
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ wireguard interface stats. See the `cap_add` and `network_mode` options on the d
 | `SESSION_SECRET`            | Used to encrypt the session cookies. Set this to a random value.                                    |
 | `WGUI_USERNAME`             | The username for the login page. (default `admin`)                                                  |
 | `WGUI_PASSWORD`             | The password for the user on the login page. (default `admin`)                                      |
+| `WGUI_ENDPOINT_ADDRESS`     | The default endpoint address used in global settings. (default is your public IP address)           |
 | `WGUI_DNS`                  | The default DNS servers (comma-separated-list) used in the global settings. (default `1.1.1.1`)     |
 | `WGUI_MTU`                  | The default MTU used in global settings. (default `1450`)                                           |
 | `WGUI_PERSISTENT_KEEPALIVE` | The default persistent keepalive for WireGuard in global settings. (default `15`)                   |

--- a/model/client_defaults.go
+++ b/model/client_defaults.go
@@ -1,0 +1,9 @@
+package model
+
+// Defaults for creation of new clients used in the templates
+type ClientDefaults struct {
+	AllowedIps          []string
+	ExtraAllowedIps     []string
+	UseServerDNS        bool
+	EnableAfterCreation bool
+}

--- a/store/jsondb/jsondb.go
+++ b/store/jsondb/jsondb.go
@@ -88,7 +88,7 @@ func (o *JsonDB) Init() error {
 		}
 
 		globalSetting := new(model.GlobalSetting)
-		globalSetting.EndpointAddress = publicInterface.IPAddress
+		globalSetting.EndpointAddress = util.LookupEnvOrString(util.EndpointAddressEnvVar, publicInterface.IPAddress)
 		globalSetting.DNSServers = util.LookupEnvOrStrings(util.DNSEnvVar, []string{util.DefaultDNS})
 		globalSetting.MTU = util.LookupEnvOrInt(util.MTUEnvVar, util.DefaultMTU)
 		globalSetting.PersistentKeepalive = util.LookupEnvOrInt(util.PersistentKeepaliveEnvVar, util.DefaultPersistentKeepalive)

--- a/store/jsondb/jsondb.go
+++ b/store/jsondb/jsondb.go
@@ -57,8 +57,10 @@ func (o *JsonDB) Init() error {
 	// server's interface
 	if _, err := os.Stat(serverInterfacePath); os.IsNotExist(err) {
 		serverInterface := new(model.ServerInterface)
-		serverInterface.Addresses = []string{util.DefaultServerAddress}
-		serverInterface.ListenPort = util.DefaultServerPort
+		serverInterface.Addresses = util.LookupEnvOrStrings(util.ServerAddressesEnvVar, []string{util.DefaultServerAddress})
+		serverInterface.ListenPort = util.LookupEnvOrInt(util.ServerListenPortEnvVar, util.DefaultServerPort)
+		serverInterface.PostUp = util.LookupEnvOrString(util.ServerPostUpScriptEnvVar, "")
+		serverInterface.PostDown = util.LookupEnvOrString(util.ServerPostDownScriptEnvVar, "")
 		serverInterface.UpdatedAt = time.Now().UTC()
 		o.conn.Write("server", "interfaces", serverInterface)
 	}
@@ -87,11 +89,11 @@ func (o *JsonDB) Init() error {
 
 		globalSetting := new(model.GlobalSetting)
 		globalSetting.EndpointAddress = publicInterface.IPAddress
-		globalSetting.DNSServers = []string{util.DefaultDNS}
-		globalSetting.MTU = util.DefaultMTU
-		globalSetting.PersistentKeepalive = util.DefaultPersistentKeepalive
-		globalSetting.ForwardMark = util.DefaultForwardMark
-		globalSetting.ConfigFilePath = util.DefaultConfigFilePath
+		globalSetting.DNSServers = util.LookupEnvOrStrings(util.DNSEnvVar, []string{util.DefaultDNS})
+		globalSetting.MTU = util.LookupEnvOrInt(util.MTUEnvVar, util.DefaultMTU)
+		globalSetting.PersistentKeepalive = util.LookupEnvOrInt(util.PersistentKeepaliveEnvVar, util.DefaultPersistentKeepalive)
+		globalSetting.ForwardMark = util.LookupEnvOrString(util.ForwardMarkEnvVar, util.DefaultForwardMark)
+		globalSetting.ConfigFilePath = util.LookupEnvOrString(util.ConfigFilePathEnvVar, util.DefaultConfigFilePath)
 		globalSetting.UpdatedAt = time.Now().UTC()
 		o.conn.Write("server", "global_settings", globalSetting)
 	}
@@ -99,8 +101,8 @@ func (o *JsonDB) Init() error {
 	// user info
 	if _, err := os.Stat(userPath); os.IsNotExist(err) {
 		user := new(model.User)
-		user.Username = util.GetCredVar(util.UsernameEnvVar, util.DefaultUsername)
-		user.Password = util.GetCredVar(util.PasswordEnvVar, util.DefaultPassword)
+		user.Username = util.LookupEnvOrString(util.UsernameEnvVar, util.DefaultUsername)
+		user.Password = util.LookupEnvOrString(util.PasswordEnvVar, util.DefaultPassword)
 		o.conn.Write("server", "users", user)
 	}
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -175,7 +175,7 @@
                                     </i>
                                 </label>
                                 <input type="text" data-role="tagsinput" class="form-control" id="client_allowed_ips"
-                                    value="0.0.0.0/0">
+                                    value="{{ StringsJoin .client_defaults.AllowedIps "," }}">
                             </div>
                             <div class="form-group">
                                 <label for="client_extra_allowed_ips" class="control-label">Extra Allowed IPs
@@ -184,11 +184,11 @@
                                        client. These addresses will be included in 'AllowedIPs' of WG server config">
                                     </i>
                                 </label>
-                                <input type="text" data-role="tagsinput" class="form-control" id="client_extra_allowed_ips">
+                                <input type="text" data-role="tagsinput" class="form-control" id="client_extra_allowed_ips" value="{{ StringsJoin .client_defaults.ExtraAllowedIps "," }}">
                             </div>
                             <div class="form-group">
                                 <div class="icheck-primary d-inline">
-                                    <input type="checkbox" id="use_server_dns" checked>
+                                    <input type="checkbox" id="use_server_dns" {{ if .client_defaults.UseServerDNS }}checked{{ end }}>
                                     <label for="use_server_dns">
                                         Use server DNS
                                     </label>
@@ -196,7 +196,7 @@
                             </div>
                             <div class="form-group">
                                 <div class="icheck-primary d-inline">
-                                    <input type="checkbox" id="enabled" checked>
+                                    <input type="checkbox" id="enabled" {{ if .client_defaults.EnableAfterCreation }}checked{{ end }}>
                                     <label for="enabled">
                                         Enable after creation
                                     </label>

--- a/util/config.go
+++ b/util/config.go
@@ -34,6 +34,7 @@ const (
 	DefaultConfigFilePath                  = "/etc/wireguard/wg0.conf"
 	UsernameEnvVar                         = "WGUI_USERNAME"
 	PasswordEnvVar                         = "WGUI_PASSWORD"
+	EndpointAddressEnvVar                  = "WGUI_ENDPOINT_ADDRESS"
 	DNSEnvVar                              = "WGUI_DNS"
 	MTUEnvVar                              = "WGUI_MTU"
 	PersistentKeepaliveEnvVar              = "WGUI_PERSISTENT_KEEPALIVE"

--- a/util/config.go
+++ b/util/config.go
@@ -23,17 +23,30 @@ var (
 )
 
 const (
-	DefaultUsername            = "admin"
-	DefaultPassword            = "admin"
-	DefaultServerAddress       = "10.252.1.0/24"
-	DefaultServerPort          = 51820
-	DefaultDNS                 = "1.1.1.1"
-	DefaultMTU                 = 1450
-	DefaultPersistentKeepalive = 15
-	DefaultForwardMark         = "0xca6c"
-	DefaultConfigFilePath      = "/etc/wireguard/wg0.conf"
-	UsernameEnvVar             = "WGUI_USERNAME"
-	PasswordEnvVar             = "WGUI_PASSWORD"
+	DefaultUsername                        = "admin"
+	DefaultPassword                        = "admin"
+	DefaultServerAddress                   = "10.252.1.0/24"
+	DefaultServerPort                      = 51820
+	DefaultDNS                             = "1.1.1.1"
+	DefaultMTU                             = 1450
+	DefaultPersistentKeepalive             = 15
+	DefaultForwardMark                     = "0xca6c"
+	DefaultConfigFilePath                  = "/etc/wireguard/wg0.conf"
+	UsernameEnvVar                         = "WGUI_USERNAME"
+	PasswordEnvVar                         = "WGUI_PASSWORD"
+	DNSEnvVar                              = "WGUI_DNS"
+	MTUEnvVar                              = "WGUI_MTU"
+	PersistentKeepaliveEnvVar              = "WGUI_PERSISTENT_KEEPALIVE"
+	ForwardMarkEnvVar                      = "WGUI_FORWARD_MARK"
+	ConfigFilePathEnvVar                   = "WGUI_CONFIG_FILE_PATH"
+	ServerAddressesEnvVar                  = "WGUI_SERVER_INTERFACE_ADDRESSES"
+	ServerListenPortEnvVar                 = "WGUI_SERVER_LISTEN_PORT"
+	ServerPostUpScriptEnvVar               = "WGUI_SERVER_POST_UP_SCRIPT"
+	ServerPostDownScriptEnvVar             = "WGUI_SERVER_POST_DOWN_SCRIPT"
+	DefaultClientAllowedIpsEnvVar          = "WGUI_DEFAULT_CLIENT_ALLOWED_IPS"
+	DefaultClientExtraAllowedIpsEnvVar     = "WGUI_DEFAULT_CLIENT_EXTRA_ALLOWED_IPS"
+	DefaultClientUseServerDNSEnvVar        = "WGUI_DEFAULT_CLIENT_USE_SERVER_DNS"
+	DefaultClientEnableAfterCreationEnvVar = "WGUI_DEFAULT_CLIENT_ENABLE_AFTER_CREATION"
 )
 
 func ParseBasePath(basePath string) string {

--- a/util/util.go
+++ b/util/util.go
@@ -77,6 +77,17 @@ func BuildClientConfig(client model.Client, server model.Server, setting model.G
 	return strConfig
 }
 
+// Read the default values for creating a new client from the environment or use sane defaults
+func ClientDefaultsFromEnv() model.ClientDefaults {
+	client_defaults := model.ClientDefaults{}
+	client_defaults.AllowedIps = LookupEnvOrStrings(DefaultClientAllowedIpsEnvVar, []string{"0.0.0.0/0"})
+	client_defaults.ExtraAllowedIps = LookupEnvOrStrings(DefaultClientExtraAllowedIpsEnvVar, []string{})
+	client_defaults.UseServerDNS = LookupEnvOrBool(DefaultClientUseServerDNSEnvVar, true)
+	client_defaults.EnableAfterCreation = LookupEnvOrBool(DefaultClientEnableAfterCreationEnvVar, true)
+
+	return client_defaults
+}
+
 // ValidateCIDR to validate a network CIDR
 func ValidateCIDR(cidr string) bool {
 	_, _, err := net.ParseCIDR(cidr)
@@ -440,10 +451,9 @@ func LookupEnvOrInt(key string, defaultVal int) int {
 	return defaultVal
 }
 
-// GetCredVar reads value from environment variable or returns fallback
-func GetCredVar(key, fallback string) string {
-	if value, ok := os.LookupEnv(key); ok {
-		return value
+func LookupEnvOrStrings(key string, defaultVal []string) []string {
+	if val, ok := os.LookupEnv(key); ok {
+		return strings.Split(val, ",")
 	}
-	return fallback
+	return defaultVal
 }


### PR DESCRIPTION
Hi,

first of all, thank you for this awesome project!

I added a bunch of environment variables which can set defaults for many of the values visible in the web-interface. This makes it easier to automatically deploy wireguard-ui e.g. with Ansible, K8S, etc. with a predefined configuration. This also includes the option to control the defaults entered in the `New Client` dialog, which helps reducing errors where e.g. a CIDR of `0.0.0.0/0`  is not suitable as only a number of subnets should be routed to the WireGuard server.

I welcome any suggestions to my changes and would be happy to see this merged upstream.

#99 would be fixed by this.