### PR TITLE
Add MTU to client configs

### DIFF
--- a/templates/global_settings.html
+++ b/templates/global_settings.html
@@ -91,9 +91,9 @@ Global Settings
                             <dt>2. DNS Servers</dt>
                             <dd>The DNS servers will be set to client config.</dd>
                             <dt>3. MTU</dt>
-                            <dd>The MTU will be set to server config. By default it is <code>1420</code>. You might want
+                            <dd>The MTU will be set to server and client config. By default it is <code>1420</code>. You might want
                                 to adjust the MTU size if your connection (e.g PPPoE, 3G, satellite network, etc) has a low MTU.</dd>
-                            <dd>Leave blank to omit this setting in the Server config.</dd>
+                            <dd>Leave blank to omit this setting in the configs.</dd>
                             <dt>4. Persistent Keepalive</dt>
                             <dd>By default, WireGuard peers remain silent while they do not need to communicate,
                                 so peers located behind a NAT and/or firewall may be unreachable from other peers

--- a/util/util.go
+++ b/util/util.go
@@ -28,6 +28,7 @@ func BuildClientConfig(client model.Client, server model.Server, setting model.G
 	if client.UseServerDNS {
 		clientDNS = fmt.Sprintf("DNS = %s\n", strings.Join(setting.DNSServers, ","))
 	}
+	clientMTU := fmt.Sprintf("MTU = %d\n", setting.MTU)
 
 	// Peer section
 	peerPublicKey := fmt.Sprintf("PublicKey = %s\n", server.KeyPair.PublicKey)
@@ -66,6 +67,7 @@ func BuildClientConfig(client model.Client, server model.Server, setting model.G
 		clientAddress +
 		clientPrivateKey +
 		clientDNS +
+		clientMTU +
 		forwardMark +
 		"\n[Peer]\n" +
 		peerPublicKey +

--- a/util/util.go
+++ b/util/util.go
@@ -28,7 +28,10 @@ func BuildClientConfig(client model.Client, server model.Server, setting model.G
 	if client.UseServerDNS {
 		clientDNS = fmt.Sprintf("DNS = %s\n", strings.Join(setting.DNSServers, ","))
 	}
-	clientMTU := fmt.Sprintf("MTU = %d\n", setting.MTU)
+	clientMTU := ""
+	if setting.MTU > 0 {
+		clientMTU = fmt.Sprintf("MTU = %d\n", setting.MTU)
+	}
 
 	// Peer section
 	peerPublicKey := fmt.Sprintf("PublicKey = %s\n", server.KeyPair.PublicKey)


### PR DESCRIPTION
This PR extends the client config generation code to add the MTU from the global settings to make sure both sides use the same MTU.

```ini
[Interface]
Address = 10.252.1.1/32
PrivateKey = ...
DNS = 1.1.1.1
MTU = 1450
FwMark = 0xca69

[Peer]
PublicKey = ...
PresharedKey = ...
AllowedIPs = 0.0.0.0/0
Endpoint = ...
PersistentKeepalive = 15
```