### PR TITLE
Disable automatic endpoint address detection when endpoint is supplied

### DIFF
--- a/store/jsondb/jsondb.go
+++ b/store/jsondb/jsondb.go
@@ -81,14 +81,18 @@ func (o *JsonDB) Init() error {
 
 	// global settings
 	if _, err := os.Stat(globalSettingPath); os.IsNotExist(err) {
-
-		publicInterface, err := util.GetPublicIP()
-		if err != nil {
-			return err
+		endpointAddress := util.LookupEnvOrString(util.EndpointAddressEnvVar, "")
+		if endpointAddress == "" {
+			// automatically find an external IP address
+			publicInterface, err := util.GetPublicIP()
+			if err != nil {
+				return err
+			}
+			endpointAddress = publicInterface.IPAddress
 		}
 
 		globalSetting := new(model.GlobalSetting)
-		globalSetting.EndpointAddress = util.LookupEnvOrString(util.EndpointAddressEnvVar, publicInterface.IPAddress)
+		globalSetting.EndpointAddress = endpointAddress
 		globalSetting.DNSServers = util.LookupEnvOrStrings(util.DNSEnvVar, []string{util.DefaultDNS})
 		globalSetting.MTU = util.LookupEnvOrInt(util.MTUEnvVar, util.DefaultMTU)
 		globalSetting.PersistentKeepalive = util.LookupEnvOrInt(util.PersistentKeepaliveEnvVar, util.DefaultPersistentKeepalive)


### PR DESCRIPTION
Currently, the dynamic endpoint address detection runs, regardless of whether it's needed. On IPv6-only servers, this might result in a panic. This PR disables the detection when the `WGUI_ENDPOINT_ADDRESS` parameter is supplied.

This should also help making IPv6-only environments work when the `WGUI_ENDPOINT_ADDRESS` parameter is set (#129).