### PR TITLE
Fix login redirect problems.

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -85,7 +85,7 @@
         if (nextURL) {
             window.location.href = nextURL;
         } else {
-            window.location.href = '/wireguard/';
+            window.location.href = '/{{.basePath}}';
         } 
     }
 </script>


### PR DESCRIPTION
After login, my browser gets a 404 for `/wireguard`. `wireguard` might not be explicitly set by `BASE_PATH`, so just use the `{{.basePath}}` instead.

Fixes #259.