### PR TITLE
Fix doubled tags on reload

### DIFF
--- a/templates/global_settings.html
+++ b/templates/global_settings.html
@@ -199,6 +199,7 @@ Global Settings
 
         // Load DNS server to the form
         {{range .globalSettings.DNSServers}}
+        $("#dns_servers").removeTag('{{.}}');
         $("#dns_servers").addTag('{{.}}');
         {{end}}
 

--- a/templates/server.html
+++ b/templates/server.html
@@ -165,6 +165,7 @@ Wireguard Server Settings
 
         // Load server addresses to the form
         {{range .serverInterface.Addresses}}
+        $("#addresses").removeTag('{{.}}');
         $("#addresses").addTag('{{.}}');
         {{end}}
 


### PR DESCRIPTION
When reloading the UI while on `/wg-server` or `/global-settings` via the reload button (or F5) the IP tags are getting duplicated on every reload. This PR fixes this by removing maybe existing old tags when (re)loading the pages.

Original:
![before](https://user-images.githubusercontent.com/63594396/208793136-f05b6a56-abbe-4017-b311-502b142ee24f.gif)

Fixed:
![after](https://user-images.githubusercontent.com/63594396/208793145-f679948e-31ce-4020-bb4a-5412c51f4796.gif)
