### PR TITLE
Match MTU value between settings and documentation

### DIFF
--- a/templates/global_settings.html
+++ b/templates/global_settings.html
@@ -91,7 +91,7 @@ Global Settings
                             <dt>2. DNS Servers</dt>
                             <dd>The DNS servers will be set to client config.</dd>
                             <dt>3. MTU</dt>
-                            <dd>The MTU will be set to server and client config. By default it is <code>1420</code>. You might want
+                            <dd>The MTU will be set to server and client config. By default it is <code>1450</code>. You might want
                                 to adjust the MTU size if your connection (e.g PPPoE, 3G, satellite network, etc) has a low MTU.</dd>
                             <dd>Leave blank to omit this setting in the configs.</dd>
                             <dt>4. Persistent Keepalive</dt>


### PR DESCRIPTION
Under Global Settings, the MTU value on the left is by default set to 1450, but the documentation claims 1420. This updates the documentation to match the correct default value.