### PR TITLE
Disable cgo when building release binary with ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,7 @@ jobs:
         goos: ${{ matrix.goos }}
         goarch: ${{ matrix.goarch }}
         goversion: "https://dl.google.com/go/go1.16.1.linux-amd64.tar.gz"
+        pre_command: export CGO_ENABLED=0
         binary_name: "wireguard-ui"
         build_flags: -v
         ldflags: -X "main.appVersion=${{ env.APP_VERSION }}" -X "main.buildTime=${{ env.BUILD_TIME }}" -X main.gitCommit=${{ github.sha }} -X main.gitRef=${{ github.ref }}


### PR DESCRIPTION
This PR adds the `CGO_ENABLED=0` env variable to the release ci which pushes a binary build when a new release is created. This allows the binary to run on non-libc systems like Alpine Linux (#318).