### PR TITLE
Add more docker-compose examples

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -25,3 +25,6 @@ docker-compose*
 db
 assets
 wireguard-ui
+
+# Examples
+examples

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ rice-box.go
 # IDEs
 .vscode
 .idea
+
+# Examples
+examples/docker-compose/config
+examples/docker-compose/db

--- a/README.md
+++ b/README.md
@@ -27,22 +27,12 @@ Download the binary file from the release page and run it directly on the host m
 
 ### Using docker compose
 
-You can take a look at this example
-of [docker-compose.yml](https://github.com/ngoduykhanh/wireguard-ui/blob/master/docker-compose.yaml). Please adjust
-volume mount points to work with your setup. Then run it like below:
+The [examples/docker-compose](examples/docker-compose) folder contains example docker-compose files.
+Choose the example which fits you the most, adjust the configuration for your needs, then run it like below:
 
 ```
 docker-compose up
 ```
-
-Note:
-
-- There is a Status page that needs docker to be able to access the network of the host in order to read the
-  wireguard interface stats. See the `cap_add` and `network_mode` options on the docker-compose.yaml
-- Similarly, the `WGUI_MANAGE_START` and `WGUI_MANAGE_RESTART` settings need the same access, in order to restart the
-  wireguard interface.
-- Because the `network_mode` is set to `host`, we don't need to specify the exposed ports. The app will listen on
-  port `5000` by default.
 
 ## Environment Variables
 

--- a/examples/docker-compose/README.md
+++ b/examples/docker-compose/README.md
@@ -1,0 +1,30 @@
+## Prerequisites
+
+### Kernel Module
+
+Depending on if the Wireguard kernel module is available on your system you have more or less choices which example to use.
+
+You can check if the kernel modules are available via the following command:
+```shell
+modprobe wireguard
+```
+
+If the command exits successfully and doesn't print an error the kernel modules are available.
+If it does error, you either have to install them manually (or activate if deactivated) or use an userspace implementation.
+For an example of an userspace implementation, see _borigtun_.
+
+### Credentials
+
+Username and password for all examples is `admin` by default.
+For security reasons it's highly recommended to change them before the first startup.
+
+## Examples
+- **[system](system.yml)**
+
+  If you have Wireguard already installed on your system and only want to run the UI in docker this might fit the most.
+- **[linuxserver](linuxserver.yml)**
+
+  If you have the Wireguard kernel modules installed (included in the mainline kernel since version 5.6) but want it running inside of docker, this might fit the most.
+- **[boringtun](boringtun.yml)**
+
+  If Wireguard kernel modules are not available, you can switch to an userspace implementation like [boringtun](https://github.com/cloudflare/boringtun).

--- a/examples/docker-compose/boringtun.yml
+++ b/examples/docker-compose/boringtun.yml
@@ -1,0 +1,43 @@
+version: "3"
+
+services:
+  boringtun:
+    image: ghcr.io/ntkme/boringtun:edge
+    command:
+      - wg0
+    container_name: boringtun
+    # use the network of the 'wireguard-ui' service. this enables to show active clients in the status page
+    network_mode: service:wireguard-ui
+    cap_add:
+      - NET_ADMIN
+    volumes:
+      - /dev/net/tun:/dev/net/tun
+      - ./config:/etc/wireguard
+
+  wireguard-ui:
+    image: ngoduykhanh/wireguard-ui:latest
+    container_name: wireguard-ui
+    cap_add:
+      - NET_ADMIN
+    environment:
+      - SENDGRID_API_KEY
+      - EMAIL_FROM_ADDRESS
+      - EMAIL_FROM_NAME
+      - SESSION_SECRET
+      - WGUI_USERNAME=admin
+      - WGUI_PASSWORD=admin
+      - WG_CONF_TEMPLATE
+      - WGUI_MANAGE_START=true
+      - WGUI_MANAGE_RESTART=true
+    logging:
+      driver: json-file
+      options:
+        max-size: 50m
+    volumes:
+      - ./db:/app/db
+      - ./config:/etc/wireguard
+    ports:
+      # port for wireguard-ui
+      - "5000:5000"
+      # port of the wireguard server. this must be set here as the `boringtun` container joins the network of this container and hasn't its own network over which it could publish the ports
+      - "51820:51820/udp"

--- a/examples/docker-compose/linuxserver.yml
+++ b/examples/docker-compose/linuxserver.yml
@@ -1,0 +1,42 @@
+version: "3"
+
+services:
+  wireguard:
+    image: linuxserver/wireguard:latest
+    container_name: wireguard
+    cap_add:
+      - NET_ADMIN
+    volumes:
+      - ./config:/config
+    ports:
+      # port for wireguard-ui. this must be set here as the `wireguard-ui` container joins the network of this container and hasn't its own network over which it could publish the ports
+      - "5000:5000"
+      # port of the wireguard server
+      - "51820:51820/udp"
+
+  wireguard-ui:
+    image: ngoduykhanh/wireguard-ui:latest
+    container_name: wireguard-ui
+    depends_on:
+      - wireguard
+    cap_add:
+      - NET_ADMIN
+    # use the network of the 'wireguard' service. this enables to show active clients in the status page
+    network_mode: service:wireguard
+    environment:
+      - SENDGRID_API_KEY
+      - EMAIL_FROM_ADDRESS
+      - EMAIL_FROM_NAME
+      - SESSION_SECRET
+      - WGUI_USERNAME=admin
+      - WGUI_PASSWORD=admin
+      - WG_CONF_TEMPLATE
+      - WGUI_MANAGE_START=true
+      - WGUI_MANAGE_RESTART=true
+    logging:
+      driver: json-file
+      options:
+        max-size: 50m
+    volumes:
+      - ./db:/app/db
+      - ./config:/etc/wireguard

--- a/examples/docker-compose/system.yml
+++ b/examples/docker-compose/system.yml
@@ -1,0 +1,27 @@
+version: "3"
+
+services:
+  wireguard-ui:
+    image: ngoduykhanh/wireguard-ui:latest
+    container_name: wireguard-ui
+    cap_add:
+      - NET_ADMIN
+    # required to show active clients. with this set, you don't need to expose the ui port (5000) anymore
+    network_mode: host
+    environment:
+      - SENDGRID_API_KEY
+      - EMAIL_FROM_ADDRESS
+      - EMAIL_FROM_NAME
+      - SESSION_SECRET
+      - WGUI_USERNAME=admin
+      - WGUI_PASSWORD=admin
+      - WG_CONF_TEMPLATE
+      - WGUI_MANAGE_START=false
+      - WGUI_MANAGE_RESTART=false
+    logging:
+      driver: json-file
+      options:
+        max-size: 50m
+    volumes:
+      - ./db:/app/db
+      - /etc/wireguard:/etc/wireguard


### PR DESCRIPTION
This PR adds some more docker compose examples:
- wireguard on the host and wgui via docker
- wireguard and wgui via docker (_related_: #54, #238, #317, #338)
- userspace wireguard implementation ([boringtun](https://github.com/cloudflare/boringtun)) and wgui via docker (_related_: maybe #232?)