### PR TITLE
Hide user settings if login is disabled

### DIFF
--- a/main.go
+++ b/main.go
@@ -128,10 +128,11 @@ func main() {
 		panic(err)
 	}
 	// set app extra data
-	extraData := make(map[string]string)
+	extraData := make(map[string]interface{})
 	extraData["appVersion"] = appVersion
 	extraData["gitCommit"] = gitCommit
 	extraData["basePath"] = util.BasePath
+	extraData["loginDisabled"] = flagDisableLogin
 
 	// strip the "templates/" prefix from the embedded directory so files can be read by their direct name (e.g.
 	// "base.html" instead of "templates/base.html")

--- a/router/router.go
+++ b/router/router.go
@@ -19,7 +19,7 @@ import (
 // TemplateRegistry is a custom html/template renderer for Echo framework
 type TemplateRegistry struct {
 	templates map[string]*template.Template
-	extraData map[string]string
+	extraData map[string]interface{}
 }
 
 // Render e.Renderer interface
@@ -48,7 +48,7 @@ func (t *TemplateRegistry) Render(w io.Writer, name string, data interface{}, c 
 }
 
 // New function
-func New(tmplDir fs.FS, extraData map[string]string, secret []byte) *echo.Echo {
+func New(tmplDir fs.FS, extraData map[string]interface{}, secret []byte) *echo.Echo {
 	e := echo.New()
 	e.Use(session.Middleware(sessions.NewCookieStore(secret)))
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -145,6 +145,7 @@
                                 </p>
                             </a>
                         </li>
+                        {{if not .loginDisabled}}
                         <li class="nav-item">
                             <a href="{{.basePath}}/users-settings" class="nav-link {{if eq .baseData.Active "users-settings" }}active{{end}}">
                             <i class="nav-icon fas fa-cog"></i>
@@ -153,6 +154,7 @@
                             </p>
                             </a>
                         </li>
+                        {{end}}
                         {{end}}
 
                         <li class="nav-header">UTILITIES</li>


### PR DESCRIPTION
If the login is disabled (`--disable-login` flag), the user management page returns a `{"message":"Not Found"}` json message (#356). This PR removes the user management menu item if login is disabled.