### PR TITLE
README.md: use "systemctl reload"

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ After=network.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/systemctl restart wg-quick@wg0.service
+ExecStart=systemctl reload wg-quick@wg0.service
 
 [Install]
 RequiredBy=wgui.path


### PR DESCRIPTION
This fixes two problems:

1\) systemctl may not live in /usr/bin/systemctl but in /bin. This is what I got on my Debian Bullseye that was upgraded over many generations:


	systemd[1]: Starting wg0-reload.service...
	systemd[1609458]: wg0-reload.service: Failed to locate executable /usr/bin/systemctl: No such file or directory
	systemd[1609458]: wg0-reload.service: Failed at step EXEC spawning /usr/bin/systemctl: No such file or directory
	systemd[1]: wg0-reload.service: Main process exited, code=exited, status=203/EXEC
	systemd[1]: wg0-reload.service: Failed with result 'exit-code'.
	systemd[1]: Failed to start wg0-reload.service.

After this change:

	systemd[1]: Starting wg0-reload.service...
	systemd[1]: Reloading WireGuard via wg-quick(8) for wg0.
	systemd[1]: Reloaded WireGuard via wg-quick(8) for wg0.
	systemd[1]: wg0-reload.service: Succeeded.
	systemd[1]: Finished wg0-reload.service.

The docs for ExecStart say

	https://www.freedesktop.org/software/systemd/man/systemd.service.html :

	[...] either an absolute path to an executable or a simple file name without any slashes

So this is OK, and works fine as tested here.

2\) Using "reload" instead of "restart" avoids breaking existing connections.

Supersedes https://github.com/ngoduykhanh/wireguard-ui/pull/316 Fixes https://github.com/ngoduykhanh/wireguard-ui/issues/228 Fixes https://github.com/ngoduykhanh/wireguard-ui/issues/167