### PR TITLE
chore: remove healthcheck from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,5 +73,4 @@ RUN chmod +x wg-ui
 COPY init.sh .
 
 EXPOSE 5000/tcp
-HEALTHCHECK CMD ["wget","--output-document=-","--quiet","--tries=1","http://127.0.0.1:$(echo ${BIND_ADDRESS:-5000} | cut -d ':' -f2)/_health"]
 ENTRYPOINT ["./init.sh"]


### PR DESCRIPTION
The healthcheck should be done outside the Docker container itself.
E.g
- Docker compose [healthcheck](https://docs.docker.com/compose/compose-file/compose-file-v3/#healthcheck)
- Kubernetes [Liveness Readiness](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)