### PR TITLE
secure jsondb user perms

### DIFF
--- a/store/jsondb/jsondb.go
+++ b/store/jsondb/jsondb.go
@@ -68,6 +68,7 @@ func (o *JsonDB) Init() error {
 		serverInterface.PostDown = util.LookupEnvOrString(util.ServerPostDownScriptEnvVar, "")
 		serverInterface.UpdatedAt = time.Now().UTC()
 		o.conn.Write("server", "interfaces", serverInterface)
+		os.Chmod(serverInterfacePath, 0600)
 	}
 
 	// server's key pair
@@ -82,6 +83,7 @@ func (o *JsonDB) Init() error {
 		serverKeyPair.PublicKey = key.PublicKey().String()
 		serverKeyPair.UpdatedAt = time.Now().UTC()
 		o.conn.Write("server", "keypair", serverKeyPair)
+		os.Chmod(serverKeyPairPath, 0600)
 	}
 
 	// global settings
@@ -106,14 +108,16 @@ func (o *JsonDB) Init() error {
 		globalSetting.ConfigFilePath = util.LookupEnvOrString(util.ConfigFilePathEnvVar, util.DefaultConfigFilePath)
 		globalSetting.UpdatedAt = time.Now().UTC()
 		o.conn.Write("server", "global_settings", globalSetting)
+		os.Chmod(globalSettingPath, 0600)
 	}
-	
+
 	// hashes
 	if _, err := os.Stat(hashesPath); os.IsNotExist(err) {
 		clientServerHashes := new(model.ClientServerHashes)
 		clientServerHashes.Client = "none"
 		clientServerHashes.Server = "none"
 		o.conn.Write("server", "hashes", clientServerHashes)
+		os.Chmod(hashesPath, 0600)
 	}
 
 	// user info
@@ -132,6 +136,7 @@ func (o *JsonDB) Init() error {
 			user.PasswordHash = hash
 		}
 		o.conn.Write("users", user.Username, user)
+		os.Chmod(path.Join(path.Join(o.dbPath, "users"), user.Username+".json"), 0600)
 	}
 
 	return nil
@@ -175,7 +180,10 @@ func (o *JsonDB) GetUserByName(username string) (model.User, error) {
 
 // SaveUser func to save user in the database
 func (o *JsonDB) SaveUser(user model.User) error {
-	return o.conn.Write("users", user.Username, user)
+	userPath := path.Join(path.Join(o.dbPath, "users"), user.Username+".json")
+	output := o.conn.Write("users", user.Username, user)
+	os.Chmod(userPath, 0600)
+	return output
 }
 
 // DeleteUser func to remove user from the database
@@ -285,7 +293,10 @@ func (o *JsonDB) GetClientByID(clientID string, qrCodeSettings model.QRCodeSetti
 }
 
 func (o *JsonDB) SaveClient(client model.Client) error {
-	return o.conn.Write("clients", client.ID, client)
+	clientPath := path.Join(path.Join(o.dbPath, "clients"), client.ID+".json")
+	output := o.conn.Write("clients", client.ID, client)
+	os.Chmod(clientPath, 0600)
+	return output
 }
 
 func (o *JsonDB) DeleteClient(clientID string) error {
@@ -293,15 +304,24 @@ func (o *JsonDB) DeleteClient(clientID string) error {
 }
 
 func (o *JsonDB) SaveServerInterface(serverInterface model.ServerInterface) error {
-	return o.conn.Write("server", "interfaces", serverInterface)
+	serverInterfacePath := path.Join(path.Join(o.dbPath, "server"), "interfaces.json")
+	output := o.conn.Write("server", "interfaces", serverInterface)
+	os.Chmod(serverInterfacePath, 0600)
+	return output
 }
 
 func (o *JsonDB) SaveServerKeyPair(serverKeyPair model.ServerKeypair) error {
-	return o.conn.Write("server", "keypair", serverKeyPair)
+	serverKeyPairPath := path.Join(path.Join(o.dbPath, "server"), "keypair.json")
+	output := o.conn.Write("server", "keypair", serverKeyPair)
+	os.Chmod(serverKeyPairPath, 0600)
+	return output
 }
 
 func (o *JsonDB) SaveGlobalSettings(globalSettings model.GlobalSetting) error {
-	return o.conn.Write("server", "global_settings", globalSettings)
+	globalSettingsPath := path.Join(path.Join(o.dbPath, "server"), "global_settings.json")
+	output := o.conn.Write("server", "global_settings", globalSettings)
+	os.Chmod(globalSettingsPath, 0600)
+	return output
 }
 
 func (o *JsonDB) GetPath() string {
@@ -314,5 +334,8 @@ func (o *JsonDB) GetHashes() (model.ClientServerHashes, error) {
 }
 
 func (o *JsonDB) SaveHashes(hashes model.ClientServerHashes) error {
-	return o.conn.Write("server", "hashes", hashes)
+	hashesPath := path.Join(path.Join(o.dbPath, "server"), "hashes.json")
+	output := o.conn.Write("server", "hashes", hashes)
+	os.Chmod(hashesPath, 0600)
+	return output
 }

--- a/store/jsondb/jsondb_wake_on_lan.go
+++ b/store/jsondb/jsondb_wake_on_lan.go
@@ -3,6 +3,9 @@ package jsondb
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"path"
+
 	"github.com/ngoduykhanh/wireguard-ui/model"
 )
 
@@ -65,7 +68,11 @@ func (o *JsonDB) SaveWakeOnLanHost(host model.WakeOnLanHost) error {
 		return err
 	}
 
-	return o.conn.Write(model.WakeOnLanHostCollectionName, resourceName, host)
+	wakeOnLanHostPath := path.Join(path.Join(o.dbPath, model.WakeOnLanHostCollectionName), resourceName+".json")
+	output := o.conn.Write(model.WakeOnLanHostCollectionName, resourceName, host)
+	os.Chmod(wakeOnLanHostPath, 0600)
+	return output
+
 }
 
 func (o *JsonDB) DeleteWakeOnHost(host model.WakeOnLanHost) error {


### PR DESCRIPTION
Fixes #143

Allows only user access to all jsondb files preventing the exposure of private keys and other sensitive information in the database