### PR TITLE
Update wg.conf to print FwMark if it exists

### DIFF
--- a/templates/wg.conf
+++ b/templates/wg.conf
@@ -7,6 +7,7 @@
 Address = {{$first :=true}}{{range .serverConfig.Interface.Addresses }}{{if $first}}{{$first = false}}{{else}},{{end}}{{.}}{{end}}
 ListenPort = {{ .serverConfig.Interface.ListenPort }}
 PrivateKey = {{ .serverConfig.KeyPair.PrivateKey }}
+{{if .globalSettings.FirewallMark}}FwMark = {{ .globalSettings.FirewallMark}}{{end}}
 {{if .globalSettings.MTU}}MTU = {{ .globalSettings.MTU }}{{end}}
 PostUp = {{ .serverConfig.Interface.PostUp }}
 PostDown = {{ .serverConfig.Interface.PostDown }}


### PR DESCRIPTION
Currently FwMark doesn't make it from the global settings into the config file when saved/applied