### PR TITLE
Add endpoint field to client

### DIFF
--- a/handler/routes.go
+++ b/handler/routes.go
@@ -614,6 +614,7 @@ func UpdateClient(db store.IStore) echo.HandlerFunc {
 		client.AllocatedIPs = _client.AllocatedIPs
 		client.AllowedIPs = _client.AllowedIPs
 		client.ExtraAllowedIPs = _client.ExtraAllowedIPs
+		client.Endpoint = _client.Endpoint
 		client.PublicKey = _client.PublicKey
 		client.PresharedKey = _client.PresharedKey
 		client.UpdatedAt = time.Now().UTC()

--- a/model/client.go
+++ b/model/client.go
@@ -15,6 +15,7 @@ type Client struct {
 	AllocatedIPs    []string  `json:"allocated_ips"`
 	AllowedIPs      []string  `json:"allowed_ips"`
 	ExtraAllowedIPs []string  `json:"extra_allowed_ips"`
+	Endpoint        string    `json:"endpoint"`
 	UseServerDNS    bool      `json:"use_server_dns"`
 	Enabled         bool      `json:"enabled"`
 	CreatedAt       time.Time `json:"created_at"`

--- a/templates/base.html
+++ b/templates/base.html
@@ -233,6 +233,10 @@
                                 <input type="text" data-role="tagsinput" class="form-control" id="client_extra_allowed_ips" value="{{ StringsJoin .client_defaults.ExtraAllowedIps "," }}">
                             </div>
                             <div class="form-group">
+                                <label for="client_endpoint" class="control-label">Endpoint</label>
+                                <input type="text" class="form-control" id="client_endpoint" name="client_endpoint">
+                            </div>
+                            <div class="form-group">
                                 <div class="icheck-primary d-inline">
                                     <input type="checkbox" id="use_server_dns" {{ if .client_defaults.UseServerDNS }}checked{{ end }}>
                                     <label for="use_server_dns">
@@ -413,6 +417,7 @@
             const email = $("#client_email").val();
             const allocated_ips = $("#client_allocated_ips").val().split(",");
             const allowed_ips = $("#client_allowed_ips").val().split(",");
+            const endpoint = $("#client_endpoint").val();
             let use_server_dns = false;
             let extra_allowed_ips = [];
 
@@ -434,7 +439,7 @@
             const preshared_key = $("#client_preshared_key").val();
 
             const data = {"name": name, "email": email, "allocated_ips": allocated_ips, "allowed_ips": allowed_ips,
-                "extra_allowed_ips": extra_allowed_ips, "use_server_dns": use_server_dns, "enabled": enabled,
+                "extra_allowed_ips": extra_allowed_ips, "endpoint": endpoint, "use_server_dns": use_server_dns, "enabled": enabled,
                 "public_key": public_key, "preshared_key": preshared_key};
 
             $.ajax({

--- a/templates/clients.html
+++ b/templates/clients.html
@@ -114,6 +114,10 @@ Wireguard Clients
                                id="_client_extra_allowed_ips">
                     </div>
                     <div class="form-group">
+                        <label for="_client_endpoint" class="control-label">Endpoint</label>
+                        <input type="text" class="form-control" id="_client_endpoint" name="client_endpoint">
+                    </div>
+                    <div class="form-group">
                         <div class="icheck-primary d-inline">
                             <input type="checkbox" id="_use_server_dns">
                             <label for="_use_server_dns">
@@ -477,6 +481,8 @@ Wireguard Clients
                             modal.find("#_client_extra_allowed_ips").addTag(obj);
                         });
 
+                        modal.find("#_client_endpoint").val(client.endpoint);
+
                         modal.find("#_use_server_dns").prop("checked", client.use_server_dns);
                         modal.find("#_enabled").prop("checked", client.enabled);
 
@@ -564,6 +570,8 @@ Wireguard Clients
                 extra_allowed_ips = $("#_client_extra_allowed_ips").val().split(",");
             }
 
+            const endpoint = $("#_client_endpoint").val();
+
             if ($("#_use_server_dns").is(':checked')){
                 use_server_dns = true;
             }
@@ -575,7 +583,8 @@ Wireguard Clients
             }
 
             const data = {"id": client_id, "name": name, "email": email, "allocated_ips": allocated_ips,
-                "allowed_ips": allowed_ips, "extra_allowed_ips": extra_allowed_ips, "use_server_dns": use_server_dns, "enabled": enabled, "public_key": public_key, "preshared_key": preshared_key};
+                "allowed_ips": allowed_ips, "extra_allowed_ips": extra_allowed_ips, "endpoint": endpoint,
+                "use_server_dns": use_server_dns, "enabled": enabled, "public_key": public_key, "preshared_key": preshared_key};
 
             $.ajax({
                 cache: false,

--- a/templates/wg.conf
+++ b/templates/wg.conf
@@ -20,6 +20,7 @@ Table = {{ .globalSettings.Table }}
 # Update at:    {{ .Client.UpdatedAt }}
 [Peer]
 PublicKey = {{ .Client.PublicKey }}
-{{if .Client.PresharedKey }}PresharedKey = {{ .Client.PresharedKey }}
-{{end}}AllowedIPs = {{$first :=true}}{{range .Client.AllocatedIPs }}{{if $first}}{{$first = false}}{{else}},{{end}}{{.}}{{end}}{{range .Client.ExtraAllowedIPs }},{{.}}{{end}}
-{{end}}{{end}}
+{{if .Client.PresharedKey }}PresharedKey = {{ .Client.PresharedKey }}{{end}}
+AllowedIPs = {{$first :=true}}{{range .Client.AllocatedIPs }}{{if $first}}{{$first = false}}{{else}},{{end}}{{.}}{{end}}{{range .Client.ExtraAllowedIPs }},{{.}}{{end}}{{end}}
+{{if .Client.Endpoint }}Endpoint = {{ .Client.Endpoint }}{{end}}
+{{end}}


### PR DESCRIPTION
Include the `Endpoint` field in client configurations, and save it in the server's `wg0.conf` if provided.

This is very useful when configuring a site-to-site setup, with both machines being able to reach each other.

Fix https://github.com/ngoduykhanh/wireguard-ui/issues/168, fix https://github.com/ngoduykhanh/wireguard-ui/issues/262, fix https://github.com/ngoduykhanh/wireguard-ui/issues/313, fix https://github.com/ngoduykhanh/wireguard-ui/issues/367, fix https://github.com/ngoduykhanh/wireguard-ui/issues/419.