### PR TITLE
Fix Helo Hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ docker-compose up
 | `SMTP_PASSWORD`             | The SMTP user password                                                                                                                                       | N/A                                |
 | `SMTP_AUTH_TYPE`            | The SMTP authentication type. Possible values: `PLAIN`, `LOGIN`, `NONE`                                                                                      | `NONE`                             |
 | `SMTP_ENCRYPTION`           | the encryption method. Possible values: `NONE`, `SSL`, `SSLTLS`, `TLS`, `STARTTLS`                                                                           | `STARTTLS`                         |
+| `HELLO_HOSTNAME`            | Hostname to use for the hello message. smtp-relay.gmail.com needs this set to anything but `localhost`                                                       | `localhost`                        |
 
 ### Defaults for server configuration
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ docker-compose up
 | `SMTP_PASSWORD`             | The SMTP user password                                                                                                                                       | N/A                                |
 | `SMTP_AUTH_TYPE`            | The SMTP authentication type. Possible values: `PLAIN`, `LOGIN`, `NONE`                                                                                      | `NONE`                             |
 | `SMTP_ENCRYPTION`           | the encryption method. Possible values: `NONE`, `SSL`, `SSLTLS`, `TLS`, `STARTTLS`                                                                           | `STARTTLS`                         |
-| `SMTP_HELO`             | Hostname to use for the helo message. smtp-relay.gmail.com needs this set to anything but `localhost`                                                       | `localhost`                        |
+| `SMTP_HELO`             | Hostname to use for the HELO message. smtp-relay.gmail.com needs this set to anything but `localhost`                                                       | `localhost`                        |
 
 ### Defaults for server configuration
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ docker-compose up
 | `SMTP_PASSWORD`             | The SMTP user password                                                                                                                                       | N/A                                |
 | `SMTP_AUTH_TYPE`            | The SMTP authentication type. Possible values: `PLAIN`, `LOGIN`, `NONE`                                                                                      | `NONE`                             |
 | `SMTP_ENCRYPTION`           | the encryption method. Possible values: `NONE`, `SSL`, `SSLTLS`, `TLS`, `STARTTLS`                                                                           | `STARTTLS`                         |
-| `HELLO_HOSTNAME`            | Hostname to use for the hello message. smtp-relay.gmail.com needs this set to anything but `localhost`                                                       | `localhost`                        |
+| `SMTP_HELO`             | Hostname to use for the helo message. smtp-relay.gmail.com needs this set to anything but `localhost`                                                       | `localhost`                        |
 
 ### Defaults for server configuration
 

--- a/emailer/smtp.go
+++ b/emailer/smtp.go
@@ -13,6 +13,7 @@ type SmtpMail struct {
 	port       int
 	username   string
 	password   string
+	helloHostName string
 	authType   mail.AuthType
 	encryption mail.Encryption
 	noTLSCheck bool
@@ -46,8 +47,8 @@ func encryptionType(encryptionType string) mail.Encryption {
 	}
 }
 
-func NewSmtpMail(hostname string, port int, username string, password string, noTLSCheck bool, auth string, fromName, from string, encryption string) *SmtpMail {
-	ans := SmtpMail{hostname: hostname, port: port, username: username, password: password, noTLSCheck: noTLSCheck, fromName: fromName, from: from, authType: authType(auth), encryption: encryptionType(encryption)}
+func NewSmtpMail(hostname string, port int, username string, password string, helloHostName string, noTLSCheck bool, auth string, fromName, from string, encryption string) *SmtpMail {
+	ans := SmtpMail{hostname: hostname, port: port, username: username, password: password, helloHostName: helloHostName, noTLSCheck: noTLSCheck, fromName: fromName, from: from, authType: authType(auth), encryption: encryptionType(encryption)}
 	return &ans
 }
 
@@ -66,6 +67,7 @@ func (o *SmtpMail) Send(toName string, to string, subject string, content string
 	server.Authentication = o.authType
 	server.Username = o.username
 	server.Password = o.password
+	server.Helo = o.helloHostName
 	server.Encryption = o.encryption
 	server.KeepAlive = false
 	server.ConnectTimeout = 10 * time.Second

--- a/emailer/smtp.go
+++ b/emailer/smtp.go
@@ -13,7 +13,7 @@ type SmtpMail struct {
 	port       int
 	username   string
 	password   string
-	helloHostName string
+	SmtpHelo string
 	authType   mail.AuthType
 	encryption mail.Encryption
 	noTLSCheck bool
@@ -47,8 +47,8 @@ func encryptionType(encryptionType string) mail.Encryption {
 	}
 }
 
-func NewSmtpMail(hostname string, port int, username string, password string, helloHostName string, noTLSCheck bool, auth string, fromName, from string, encryption string) *SmtpMail {
-	ans := SmtpMail{hostname: hostname, port: port, username: username, password: password, helloHostName: helloHostName, noTLSCheck: noTLSCheck, fromName: fromName, from: from, authType: authType(auth), encryption: encryptionType(encryption)}
+func NewSmtpMail(hostname string, port int, username string, password string, SmtpHelo string, noTLSCheck bool, auth string, fromName, from string, encryption string) *SmtpMail {
+	ans := SmtpMail{hostname: hostname, port: port, username: username, password: password, SmtpHelo: SmtpHelo, noTLSCheck: noTLSCheck, fromName: fromName, from: from, authType: authType(auth), encryption: encryptionType(encryption)}
 	return &ans
 }
 
@@ -67,7 +67,7 @@ func (o *SmtpMail) Send(toName string, to string, subject string, content string
 	server.Authentication = o.authType
 	server.Username = o.username
 	server.Password = o.password
-	server.Helo = o.helloHostName
+	server.Helo = o.smtpHelo
 	server.Encryption = o.encryption
 	server.KeepAlive = false
 	server.ConnectTimeout = 10 * time.Second

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ var (
 	flagBindAddress    string = "0.0.0.0:5000"
 	flagSmtpHostname   string = "127.0.0.1"
 	flagSmtpPort       int    = 25
-	flagHelloHostName  string = "localhost"
+	flagSmtpHelo  string = "localhost"
 	flagSmtpUsername   string
 	flagSmtpPassword   string
 	flagSmtpAuthType   string = "NONE"
@@ -70,7 +70,7 @@ func init() {
 	flag.StringVar(&flagBindAddress, "bind-address", util.LookupEnvOrString("BIND_ADDRESS", flagBindAddress), "Address:Port to which the app will be bound.")
 	flag.StringVar(&flagSmtpHostname, "smtp-hostname", util.LookupEnvOrString("SMTP_HOSTNAME", flagSmtpHostname), "SMTP Hostname")
 	flag.IntVar(&flagSmtpPort, "smtp-port", util.LookupEnvOrInt("SMTP_PORT", flagSmtpPort), "SMTP Port")
-	flag.StringVar(&flagHelloHostName, "hello-hostname", util.LookupEnvOrString("HELLO_HOSTNAME", flagHelloHostName), "Hello HostName")
+	flag.StringVar(&flagSmtpHelo, "smtp-helo", util.LookupEnvOrString("SMTP_HELO", flagSmtpHelo), "SMTP HELO Hostname")
 	flag.StringVar(&flagSmtpUsername, "smtp-username", util.LookupEnvOrString("SMTP_USERNAME", flagSmtpUsername), "SMTP Username")
 	flag.StringVar(&flagSmtpPassword, "smtp-password", util.LookupEnvOrString("SMTP_PASSWORD", flagSmtpPassword), "SMTP Password")
 	flag.BoolVar(&flagSmtpNoTLSCheck, "smtp-no-tls-check", util.LookupEnvOrBool("SMTP_NO_TLS_CHECK", flagSmtpNoTLSCheck), "Disable TLS verification for SMTP. This is potentially dangerous.")
@@ -89,7 +89,7 @@ func init() {
 	util.BindAddress = flagBindAddress
 	util.SmtpHostname = flagSmtpHostname
 	util.SmtpPort = flagSmtpPort
-	util.HelloHostName = flagHelloHostName
+	util.SmtpHelo = flagSmtpHelo
 	util.SmtpUsername = flagSmtpUsername
 	util.SmtpPassword = flagSmtpPassword
 	util.SmtpAuthType = flagSmtpAuthType
@@ -166,7 +166,7 @@ func main() {
 	if util.SendgridApiKey != "" {
 		sendmail = emailer.NewSendgridApiMail(util.SendgridApiKey, util.EmailFromName, util.EmailFrom)
 	} else {
-		sendmail = emailer.NewSmtpMail(util.SmtpHostname, util.SmtpPort, util.SmtpUsername, util.SmtpPassword, util.HelloHostName, util.SmtpNoTLSCheck, util.SmtpAuthType, util.EmailFromName, util.EmailFrom, util.SmtpEncryption)
+		sendmail = emailer.NewSmtpMail(util.SmtpHostname, util.SmtpPort, util.SmtpUsername, util.SmtpPassword, util.SmtpHelo, util.SmtpNoTLSCheck, util.SmtpAuthType, util.EmailFromName, util.EmailFrom, util.SmtpEncryption)
 	}
 
 	app.GET(util.BasePath+"/test-hash", handler.GetHashesChanges(db), handler.ValidSession)

--- a/util/config.go
+++ b/util/config.go
@@ -10,6 +10,7 @@ var (
 	SmtpPort       int
 	SmtpUsername   string
 	SmtpPassword   string
+	HelloHostName  string
 	SmtpNoTLSCheck bool
 	SmtpEncryption string
 	SmtpAuthType   string

--- a/util/config.go
+++ b/util/config.go
@@ -10,7 +10,7 @@ var (
 	SmtpPort       int
 	SmtpUsername   string
 	SmtpPassword   string
-	HelloHostName  string
+	SmtpHelo       string
 	SmtpNoTLSCheck bool
 	SmtpEncryption string
 	SmtpAuthType   string


### PR DESCRIPTION
Implements variable HELLO_HOSTNAME to make smtp-relay.gmail.com compatible as an email service. If not set defaults to `localhost` instead.