### PR TITLE
Make Interface PreDown setting.

### DIFF
--- a/model/server.go
+++ b/model/server.go
@@ -23,5 +23,6 @@ type ServerInterface struct {
 	ListenPort int       `json:"listen_port,string"` // ,string to get listen_port string input as int
 	UpdatedAt  time.Time `json:"updated_at"`
 	PostUp     string    `json:"post_up"`
+	PreDown    string    `json:"pre_down"`
 	PostDown   string    `json:"post_down"`
 }

--- a/templates/server.html
+++ b/templates/server.html
@@ -43,6 +43,12 @@ Wireguard Server Settings
                                        placeholder="Post Up Script" value="{{ .serverInterface.PostUp }}">
                             </div>
                             <div class="form-group">
+                                <label for="pre_down">Pre Down Script</label>
+                                <input type="text" class="form-control" id="pre_down" name="pre_down"
+                                       placeholder="Pre Down Script" value="{{ .serverInterface.PreDown }}">
+                            </div>
+
+                            <div class="form-group">
                                 <label for="post_down">Post Down Script</label>
                                 <input type="text" class="form-control" id="post_down" name="post_down"
                                        placeholder="Post Down Script" value="{{ .serverInterface.PostDown }}">
@@ -130,8 +136,9 @@ Wireguard Server Settings
             const addresses = $("#addresses").val().split(",");
             const listen_port = $("#listen_port").val();
             const post_up = $("#post_up").val();
+            const pre_down = $("#pre_down").val();
             const post_down = $("#post_down").val();
-            const data = {"addresses": addresses, "listen_port": listen_port, "post_up": post_up, "post_down": post_down};
+            const data = {"addresses": addresses, "listen_port": listen_port, "post_up": post_up, "pre_down": pre_down, "post_down": post_down};
 
             $.ajax({
                 cache: false,

--- a/templates/wg.conf
+++ b/templates/wg.conf
@@ -9,6 +9,7 @@ ListenPort = {{ .serverConfig.Interface.ListenPort }}
 PrivateKey = {{ .serverConfig.KeyPair.PrivateKey }}
 {{if .globalSettings.MTU}}MTU = {{ .globalSettings.MTU }}{{end}}
 PostUp = {{ .serverConfig.Interface.PostUp }}
+PreDown = {{ .serverConfig.Interface.PreDown }}
 PostDown = {{ .serverConfig.Interface.PostDown }}
 Table = {{ .globalSettings.Table }}
 


### PR DESCRIPTION
Added PreDown setting in wg.conf that wg-quick correctly proccessed. Needed for some cases, e.g. [wireguard kill switch](https://www.ivpn.net/knowledgebase/linux/linux-wireguard-kill-switch/)

PreUp setting can be made the same way if needed.