### PR TITLE
Fixed tag input being too small and unable to fit a CIDR

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -492,6 +492,7 @@
             'defaultText': 'Add More',
             'removeWithBackspace': true,
             'minChars': 0,
+            'minInputWidth': '100%',
             'placeholderColor': '#666666'
         });
 
@@ -503,6 +504,7 @@
             'defaultText': 'Add More',
             'removeWithBackspace': true,
             'minChars': 0,
+            'minInputWidth': '100%',
             'placeholderColor': '#666666'
         });
 
@@ -513,6 +515,7 @@
             'defaultText': 'Add More',
             'removeWithBackspace': true,
             'minChars': 0,
+            'minInputWidth': '100%',
             'placeholderColor': '#666666'
         });
 

--- a/templates/clients.html
+++ b/templates/clients.html
@@ -423,6 +423,7 @@ Wireguard Clients
                     'defaultText': 'Add More',
                     'removeWithBackspace': true,
                     'minChars': 0,
+                    'minInputWidth': '100%',
                     'placeholderColor': '#666666'
                 });
 
@@ -434,6 +435,7 @@ Wireguard Clients
                     'defaultText': 'Add More',
                     'removeWithBackspace': true,
                     'minChars': 0,
+                    'minInputWidth': '100%',
                     'placeholderColor': '#666666'
                 });
 
@@ -444,6 +446,7 @@ Wireguard Clients
                     'defaultText': 'Add More',
                     'removeWithBackspace' : true,
                     'minChars': 0,
+                    'minInputWidth': '100%',
                     'placeholderColor': '#666666'
                 })
 

--- a/templates/global_settings.html
+++ b/templates/global_settings.html
@@ -203,6 +203,7 @@ Global Settings
             'defaultText': 'Add More',
             'removeWithBackspace': true,
             'minChars': 0,
+            'minInputWidth': '100%',
             'placeholderColor': '#666666'
         });
 

--- a/templates/server.html
+++ b/templates/server.html
@@ -160,6 +160,7 @@ Wireguard Server Settings
             'defaultText': 'Add More',
             'removeWithBackspace': true,
             'minChars': 0,
+            'minInputWidth': '100%',
             'placeholderColor': '#666666'
         });
 


### PR DESCRIPTION
![image](https://github.com/ngoduykhanh/wireguard-ui/assets/11984323/06e0c68f-5fc2-4713-be2e-7eda785509ab)
> Before: Not enough space even for IPv4

![image](https://github.com/ngoduykhanh/wireguard-ui/assets/11984323/376ead90-dce7-4509-b94b-3ba7afe33085)
> After: full CIDR is visible during entry

Split from #481