### PR TITLE
Specify mimetype for email attachments

### DIFF
--- a/emailer/interface.go
+++ b/emailer/interface.go
@@ -3,6 +3,7 @@ package emailer
 type Attachment struct {
 	Name string
 	Data []byte
+	MimeType string
 }
 
 type Emailer interface {

--- a/emailer/sendgrid.go
+++ b/emailer/sendgrid.go
@@ -39,7 +39,7 @@ func (o *SendgridApiMail) Send(toName string, to string, subject string, content
 		var att mail.Attachment
 		encoded := base64.StdEncoding.EncodeToString(attachments[i].Data)
 		att.SetContent(encoded)
-		att.SetType("text/plain")
+		att.SetType(attachments[i].MimeType)
 		att.SetFilename(attachments[i].Name)
 		att.SetDisposition("attachment")
 		toAdd = append(toAdd, &att)

--- a/emailer/smtp.go
+++ b/emailer/smtp.go
@@ -91,7 +91,7 @@ func (o *SmtpMail) Send(toName string, to string, subject string, content string
 		SetBody(mail.TextHTML, content)
 
 	for _, v := range attachments {
-		email.Attach(&mail.File{Name: v.Name, Data: v.Data})
+		email.Attach(&mail.File{Name: v.Name, Data: v.Data, MimeType: v.MimeType})
 	}
 
 	err = email.Send(smtpClient)

--- a/handler/routes.go
+++ b/handler/routes.go
@@ -547,14 +547,14 @@ func EmailClient(db store.IStore, mailer emailer.Emailer, emailSubject, emailCon
 		globalSettings, _ := db.GetGlobalSettings()
 		config := util.BuildClientConfig(*clientData.Client, server, globalSettings)
 
-		cfgAtt := emailer.Attachment{Name: "wg0.conf", Data: []byte(config)}
+		cfgAtt := emailer.Attachment{Name: "wg0.conf", Data: []byte(config), MimeType: "text/conf"}
 		var attachments []emailer.Attachment
 		if clientData.Client.PrivateKey != "" {
 			qrdata, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(clientData.QRCode, "data:image/png;base64,"))
 			if err != nil {
 				return c.JSON(http.StatusInternalServerError, jsonHTTPResponse{false, "decoding: " + err.Error()})
 			}
-			qrAtt := emailer.Attachment{Name: "wg.png", Data: qrdata}
+			qrAtt := emailer.Attachment{Name: "wg.png", Data: qrdata, MimeType: "image/png"}
 			attachments = []emailer.Attachment{cfgAtt, qrAtt}
 		} else {
 			attachments = []emailer.Attachment{cfgAtt}


### PR DESCRIPTION
This fixes that some email client might not allow previewing the qrcode image.

⚠️  Note that there is a change that might go unnoticed: the text/plain of the .conf file is changed to text/conf; matching the mimetype used for downloading via the UI.

Example on Fastmail:
Before

![image](https://github.com/ngoduykhanh/wireguard-ui/assets/9844285/a82de9b9-031b-451d-9cd1-04af2a594d38)
After

![image](https://github.com/ngoduykhanh/wireguard-ui/assets/9844285/7ed2a341-64bd-4de7-a417-5e3d197856c3)
