### PR TITLE
Update about.html to open the GitHub page in a new tab (or window)

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -63,7 +63,7 @@ About
                         </div>
                         <strong>Copyright &copy;
                             <script>document.write(new Date().getFullYear())</script>
-                            <a href="https://github.com/ngoduykhanh/wireguard-ui">Wireguard UI</a>.
+                            <a href="https://github.com/ngoduykhanh/wireguard-ui" target="_blank">Wireguard UI</a>.
                         </strong> All rights reserved.
 
                     </div>


### PR DESCRIPTION
Add a target="_blank" to the github link to open it in a new tab (or window) instead of replacing the current wireguard-ui about page.

As a new Wireguard and wireguard-ui user I visited the About page and found out that after clicking the link it didn't open a new tab. That was for me a reason the create this PR.

Thanks for this package and don't feel bad to close this PR if this change isn't wanted.