### PR TITLE
Add chmod of unix socket

### DIFF
--- a/main.go
+++ b/main.go
@@ -287,6 +287,10 @@ func main() {
 		if err != nil {
 			app.Logger.Fatalf("Cannot create unix socket. Error: %v", err)
 		}
+		err = os.Chmod(util.BindAddress[6:], 0666)
+		if err != nil {
+			app.Logger.Fatalf("Cannot chmod unix socket. Error: %v", err)
+		}
 		app.Listener = l
 		app.Logger.Fatal(app.Start(""))
 	} else {


### PR DESCRIPTION
Hello.
I encountered a problem using wireguard-ui unix-sockets behind an nginx reverse-proxy. The reason was the default file mode of the unix-socket, which I couldn't fix by chmod'ing before starting wireguard-ui, because wireguard-ui would always reset the file mode.

My fix in the code sets the socket to be world read-writable. This enables the nginx reverse-proxy to use it without problems.