### PR TITLE
chore(docker): remove deprecated 'version' attribute from docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   wg:
     build: .

--- a/examples/docker-compose/boringtun.yml
+++ b/examples/docker-compose/boringtun.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   boringtun:
     image: ghcr.io/ntkme/boringtun:edge

--- a/examples/docker-compose/linuxserver.yml
+++ b/examples/docker-compose/linuxserver.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   wireguard:
     image: linuxserver/wireguard:latest

--- a/examples/docker-compose/system.yml
+++ b/examples/docker-compose/system.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   wireguard-ui:
     image: ngoduykhanh/wireguard-ui:latest


### PR DESCRIPTION
This merge request removes the deprecated version attribute from the docker-compose.yml files. Docker has deprecated the use of the version field, and it is now ignored, which can lead to confusion. By removing this attribute, we ensure that our configuration is up to date and avoid potential warnings when running docker compose up.

![image](https://github.com/user-attachments/assets/c742d34d-1993-4e8c-8413-7c0e8813355a)


Thanks