### PR TITLE
Update README.md

### DIFF
--- a/examples/docker-compose/README.md
+++ b/examples/docker-compose/README.md
@@ -6,7 +6,17 @@ Depending on if the Wireguard kernel module is available on your system you have
 
 You can check if the kernel modules are available via the following command:
 ```shell
-modprobe wireguard
+modinfo wireguard
+```
+
+This will return information about the wireguard kernel module if it is available. If it is available, you can check if it is loaded via the following command:
+```shell
+lsmod | grep wireguard
+```
+
+If it is available but not loaded, you can load the module via the following command:
+```shell
+sudo modprobe wireguard
 ```
 
 If the command exits successfully and doesn't print an error the kernel modules are available.


### PR DESCRIPTION
Added `modinfo` command to get module availability. 

Added `lsmod | grep wireguard` to check whether the module is loaded to the kernel. 

Added `sudo` to the `modprobe` command because it requires root access to modify the kernel.